### PR TITLE
Add some packaging updates to get all green with NuGet validation tooling

### DIFF
--- a/Directory.build.props
+++ b/Directory.build.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup Condition=" '$(Configuration)'=='Release' ">
     <Deterministic>true</Deterministic>
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)Honeycomb.OpenTelemetry.snk</AssemblyOriginatorKeyFile>

--- a/src/Honeycomb.OpenTelemetry/Honeycomb.OpenTelemetry.csproj
+++ b/src/Honeycomb.OpenTelemetry/Honeycomb.OpenTelemetry.csproj
@@ -3,13 +3,21 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net452;net46;net461</TargetFrameworks>
     <Description>Honeycomb OpenTelemetry SDK</Description>
-    <RootNamespace>Honeycomb.OpenTelemetry</RootNamespace>
     <Version>0.1.0</Version>
+    
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+
+    <!-- For SourceLink. See: https://github.com/dotnet/sourcelink#using-source-link-in-net-projects -->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="OpenTelemetry" Version="1.0.1" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.0.1" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
   </ItemGroup>
 
   <Choose>

--- a/src/Honeycomb.OpenTelemetry/HoneycombSdk.cs
+++ b/src/Honeycomb.OpenTelemetry/HoneycombSdk.cs
@@ -3,15 +3,24 @@ using OpenTelemetry.Trace;
 
 namespace Honeycomb.OpenTelemetry
 {
+    /// <summary>
+    /// Represents the Honeycomb SDK. 
+    /// </summary>
     public class HoneycombSdk : IDisposable
     {
         private TracerProvider _sdk;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HoneycombSdk"/> class from a given <see cref="TracerProvider"/>.
+        /// </summary>
         public HoneycombSdk(TracerProvider sdk)
         {
             _sdk = sdk;
         }
 
+        /// <summary>
+        /// Disposes this SDK.
+        /// </summary>
         public void Dispose()
         {
             ((IDisposable)_sdk).Dispose();

--- a/src/Honeycomb.OpenTelemetry/HoneycombSdkBuilder.cs
+++ b/src/Honeycomb.OpenTelemetry/HoneycombSdkBuilder.cs
@@ -7,6 +7,9 @@ using OpenTelemetry.Trace;
 
 namespace Honeycomb.OpenTelemetry
 {
+    /// <summary>
+    /// The Honeycomb SDK builder.
+    /// </summary>
     public class HoneycombSdkBuilder
     {
         private Uri _endpoint;
@@ -16,6 +19,9 @@ namespace Honeycomb.OpenTelemetry
         private Sampler _sampler = new DeterministicSampler(1); // default to always sample
         internal readonly ResourceBuilder ResourceBuilder;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HoneycombSdkBuilder"/> class with default values from your environment.
+        /// </summary>
         public HoneycombSdkBuilder()
         {
             var options = new EnvironmentOptions(Environment.GetEnvironmentVariables());
@@ -43,64 +49,97 @@ namespace Honeycomb.OpenTelemetry
             }
         }
 
+        /// <summary>
+        /// Creates a new instance of the <see cref="HoneycombSdkBuilder"/> class with a specified endpoint.
+        /// </summary>
         public HoneycombSdkBuilder WithEndpoint(string endpoint)
         {
             return WithEndpoint(new Uri(endpoint));
         }
 
+        /// <summary>
+        /// Creates a new instance of the <see cref="HoneycombSdkBuilder"/> class with a specified endpoint.
+        /// </summary>
         public HoneycombSdkBuilder WithEndpoint(Uri endpoint)
         {
             _endpoint = endpoint;
             return this;
         }
 
+        /// <summary>
+        /// Creates a new instance of the <see cref="HoneycombSdkBuilder"/> class with a specified API key.
+        /// </summary>
         public HoneycombSdkBuilder WithAPIKey(string apiKey)
         {
             _apiKey = apiKey;
             return this;
         }
 
+        /// <summary>
+        /// Creates a new instance of the <see cref="HoneycombSdkBuilder"/> class with a specified dataset.
+        /// </summary>
         public HoneycombSdkBuilder WithDataset(string dataset)
         {
             _dataset = dataset;
             return this;
         }
 
+        /// <summary>
+        /// Creates a new instance of the <see cref="HoneycombSdkBuilder"/> class with a specified sampler.
+        /// </summary>
         public HoneycombSdkBuilder WithSampler(Sampler sampler)
         {
             _sampler = sampler;
             return this;
         }
 
+        /// <summary>
+        /// Creates a new instance of the <see cref="HoneycombSdkBuilder"/> class with  a specified sample rate.
+        /// </summary>
         public HoneycombSdkBuilder WithSampleRate(uint sampleRate)
         {
             _sampler = new DeterministicSampler(sampleRate);
             return this;
         }
 
+        /// <summary>
+        /// Creates a new instance of the <see cref="HoneycombSdkBuilder"/> class with a specified service name.
+        /// </summary>
         public HoneycombSdkBuilder WithServiceName(string serviceName)
         {
             ResourceBuilder.AddService(serviceName);
             return this;
         }
 
+        /// <summary>
+        /// Creates a new instance of the <see cref="HoneycombSdkBuilder"/> class with a specified set of resource attributes.
+        /// </summary>
         public HoneycombSdkBuilder WithResourceAttributes(params KeyValuePair<string, object>[] attributes)
         {
             ResourceBuilder.AddAttributes(attributes);
             return this;
         }
 
+        /// <summary>
+        /// Creates a new instance of the <see cref="HoneycombSdkBuilder"/> class with a specified resource attribute.
+        /// </summary>
         public HoneycombSdkBuilder WithResourceAttribute(string key, object value)
         {
             return WithResourceAttributes(new KeyValuePair<string, object>(key, value));
         }
 
+        /// <summary>
+        /// Creates a new instance of the <see cref="HoneycombSdkBuilder"/> class with a specified set of sources.
+        /// </summary>
         public HoneycombSdkBuilder WithSources(params string[] names)
         {
             _sourceNames = names;
             return this;
         }
 
+        /// <summary>
+        /// Builds a new instance of the <see cref="HoneycombSdk"/> class from the this <see cref="HoneycombSdkBuilder"/>. 
+        /// </summary>
         public HoneycombSdk Build()
         {
             if (string.IsNullOrWhiteSpace(_apiKey))


### PR DESCRIPTION
These changes make [NuGet Package Explorer](https://github.com/NuGetPackageExplorer/NuGetPackageExplorer) happy:

![image](https://user-images.githubusercontent.com/6309070/124201160-24a4f880-da8c-11eb-9905-07cbafc432a0.png)

Quick explanation of each:

* **Source Link** - this lets the package be debuggable by .NET users in an editor with source link debugging support (such as Visual Studio). It will download and load the commit-specific sources relative to the version of the package someone is using. Editor tooling can then let you step into these sources when debugging.
* **Deterministic** - this is pretty straightforward; it's indicating that the compiler that built the package produced a deterministic output. There isn't much ecosystem tooling that uses this today, but it's starting to get built on the NuGet side and I think we could see things like build systems also take advantage of it.
* **Compiler Flags** - this is the last missing piece in being able to fully replay a compilation from an artifact that built it. This embeds the switches that the C# compiler builds with into the PDB file, allowing tooling to be able to fully validate that an artifact truly came from the sources and toolset that _claim_ to have built it. This, combined with the deterministic switch, forms the basis of stuff that we'll likely see on the NuGet server side to better secure supply chains.

This is a draft, since I didn't add any packaging properties, and some more tweaks could certainly be made. Some of that is going to come down to opinion (properties in `Directory.Build.props` or project file? What versioning scheme? License expression or license file? etc.) so I figured that's best left to a review.