### PR TITLE
Update dependabot schedule to use lowecase day

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-      day: "Monday"
+      day: "monday"
     labels:
       - "type: dependencies"
     reviewers:


### PR DESCRIPTION
Dependabot is failing with a validation error because the schedule.day property should be `monday` (lowercase) as seen [here](https://github.com/honeycombio/honeycomb-opentelemetry-dotnet/pull/42/checks?check_run_id=3022102337).

Error mesage:
```
The property '#/updates/0/schedule/day' value "Monday" did not match one of the following values: monday, tuesday, wednesday, thursday, friday, saturday, sunday
```