### PR TITLE
Add multi-span support via baggage

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -118,9 +118,6 @@ csharp_style_throw_expression = true:suggestion
 csharp_style_unused_value_assignment_preference = discard_variable:suggestion
 csharp_style_unused_value_expression_statement_preference = discard_variable:silent
 
-# 'using' directive preferences
-csharp_using_directive_placement = inside_namespace:silent
-
 #### C# Formatting Rules ####
 
 # New line preferences

--- a/src/Honeycomb.OpenTelemetry/BaggageSpanProcessor.cs
+++ b/src/Honeycomb.OpenTelemetry/BaggageSpanProcessor.cs
@@ -1,0 +1,21 @@
+using OpenTelemetry;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Honeycomb.OpenTelemetry
+{
+    /// <summary>
+    /// Span processor that adds <see cref="Baggage"/> fields to every new span
+    /// </summary>
+    public class BaggageSpanProcessor : BaseProcessor<Activity>
+    {
+        /// <inheritdoc />
+        public override void OnStart(Activity activity)
+        {
+            foreach (KeyValuePair<string, string> entry in Baggage.Current)
+            {
+                activity.SetTag(entry.Key, entry.Value);
+            }
+        }
+    }
+}

--- a/src/Honeycomb.OpenTelemetry/TracerProviderBuilderExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry/TracerProviderBuilderExtensions.cs
@@ -61,6 +61,7 @@ namespace Honeycomb.OpenTelemetry
                         .AddEnvironmentVariableDetector()
                         .AddService(serviceName: options.ServiceName, serviceVersion: options.ServiceVersion)
                 )
+                .AddProcessor(new BaggageSpanProcessor())
                 .AddHttpClientInstrumentation()
                 .AddSqlClientInstrumentation();
 


### PR DESCRIPTION
* add baggage span processor
* add enrich to CORE instrumentation because [reasons](https://honeycomb.quip.com/blLtAnlQkKFR/Dotnet-Notes#ROZACAPgTby)
> AspNetCore creates activity → custom processor is called (no baggage set, yet) → OTEL listener parses context into baggage → enrich is called → custom activities are created → custom processor is called (baggage is set)
* fixes #11 