### PR TITLE
Publish everything in build folder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ jobs:
           at: .\
       - run:
           name: "Publishing to nuget.org"
-          command: dotnet.exe nuget push "build\*nupkg" -k $env:NUGET_APIKEY -s https://api.nuget.org/v3/index.json
+          command: dotnet.exe nuget push "build\" -k $env:NUGET_APIKEY -s https://api.nuget.org/v3/index.json
 
 workflows:
   version: 2


### PR DESCRIPTION
Nuget did not work without having file suffix (build\*nupkg vs build\*.nupkg), despite it working with `ls` command. Updating to publish entire build folder.