### PR TITLE
Publish specific suffix .nupkg

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ jobs:
           at: .\
       - run:
           name: "Publishing to nuget.org"
-          command: dotnet.exe nuget push "build\" -k $env:NUGET_APIKEY -s https://api.nuget.org/v3/index.json
+          command: dotnet.exe nuget push "build\*.nupkg" -k $env:NUGET_APIKEY -s https://api.nuget.org/v3/index.json
 
 workflows:
   version: 2


### PR DESCRIPTION
When publishing build folder, received an error "CircleCI received exit code 1". Updating to publish with specific suffix of ".nupkg"