### PR TITLE
Only sign builds when publishing through CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
           shell: bash.exe
       - run:
           name: "Build release package"
-          command: dotnet.exe pack -c release --output build --no-restore
+          command: dotnet.exe pack -c release --output build --no-restore -p:signed=true
       - persist_to_workspace:
           root: \
           paths:

--- a/Directory.build.props
+++ b/Directory.build.props
@@ -3,6 +3,9 @@
     <Deterministic>true</Deterministic>
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(SIGNED)' == 'true' ">
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)Honeycomb.OpenTelemetry.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,6 @@ local_nuget_source_registered: ${NUGET_PACKAGES_LOCAL}
 
 publish_local: local_nuget_source_registered
 	@echo "Publishing nuget package(s) to: ${NUGET_PACKAGES_LOCAL}\n"
-	@dotnet pack -c release -o ${NUGET_PACKAGES_LOCAL} --include-symbols
+	@dotnet pack -c release -o ${NUGET_PACKAGES_LOCAL} -p:signed=false
 
 .PHONY: build test local_nuget_source_registered publish_local

--- a/src/Honeycomb.OpenTelemetry/Honeycomb.OpenTelemetry.csproj
+++ b/src/Honeycomb.OpenTelemetry/Honeycomb.OpenTelemetry.csproj
@@ -55,7 +55,7 @@
   </ItemGroup>
   
   <Choose>
-    <When Condition=" '$(Configuration)'=='Debug' ">
+    <When Condition=" !$(DefineConstants.Contains(SIGNED)) ">
       <ItemGroup>
         <InternalsVisibleTo Include="Honeycomb.OpenTelemetry.Tests" />
       </ItemGroup>

--- a/src/Honeycomb.OpenTelemetry/Honeycomb.OpenTelemetry.csproj
+++ b/src/Honeycomb.OpenTelemetry/Honeycomb.OpenTelemetry.csproj
@@ -55,7 +55,7 @@
   </ItemGroup>
   
   <Choose>
-    <When Condition=" !$(DefineConstants.Contains(SIGNED)) ">
+    <When Condition=" $(SIGNED) != 'true' ">
       <ItemGroup>
         <InternalsVisibleTo Include="Honeycomb.OpenTelemetry.Tests" />
       </ItemGroup>


### PR DESCRIPTION
Fixes #51.

This updates the pack command to not require a local signing key based on the release configuration and is instead based on a new msbuild property called `SIGNED`. This makes it easier for local debugging to create the packages.

Only when we go through the packaging step on CI do we set the signed flag to `true`.

Also replaces the `--include-symbols` msbuild arg in the makefile as it's already set in the csproj.