### PR TITLE
Allow dependabot and forked PRs to run in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,14 +94,20 @@ workflows:
   build:
     jobs:
       - test:
-          filters: &always_filter
+          filters:
             tags:
               only: /.*/
       - package:
           context: Honeycomb Secrets for Public Repos
           requires:
             - test
-          filters: *always_filter
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore:
+                - /pull\/.*/
+                - /dependabot\/.*/
       - publish_github:
           context: Honeycomb Secrets for Public Repos
           requires:


### PR DESCRIPTION
dependabot and outside collaborators don't have access to secrets in CI -- don't attempt to run `package` for those builds
