### PR TITLE
Add prerelease flag to install command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Version `0.9.0-pre` is the only version that will contain the initial implementa
 
 You can add the package to your application by using the following command:
 
-`dotnet add package Honeycomb.OpenTelemetry`
+`dotnet add package Honeycomb.OpenTelemetry --prerelease`
 
 ### Configuration
 


### PR DESCRIPTION
## Which problem is this PR solving?
The Honeycomb.OpenTelemetry packages that is published to nuget.org are all prereleases and the install command in the README is missing the `--prerelease` flag.

## Short description of the changes
- Update install package cli command to include prerelease flag

