### PR TITLE
[fix] Remove whitespace failing build

### DIFF
--- a/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
+++ b/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
@@ -130,7 +130,6 @@ namespace Honeycomb.OpenTelemetry
 
         /// <summary>
         /// (Optional) Options delegate to configure HttpClient instrumentation.
-
         /// </summary>
         public Action<HttpClientInstrumentationOptions> ConfigureHttpClientInstrumentationOptions { get; set; }
 
@@ -141,7 +140,6 @@ namespace Honeycomb.OpenTelemetry
 
         /// <summary>
         /// (Optional) Options delegate to configure StackExchance.Redis instrumentation.
-
         /// </summary>
         public Action<StackExchangeRedisCallsInstrumentationOptions> ConfigureStackExchangeRedisClientInstrumentationOptions { get; set; }
 

--- a/src/Honeycomb.OpenTelemetry/TracerProviderBuilderExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry/TracerProviderBuilderExtensions.cs
@@ -24,7 +24,6 @@ namespace Honeycomb.OpenTelemetry
 
         /// <summary>
         /// Configures the <see cref="TracerProviderBuilder"/> to send telemetry data to Honeycomb.
-
         /// </summary>
         /// <param name="builder"><see cref="TracerProviderBuilder"/> being configured.</param>
         /// <param name="configureHoneycombOptions">Action delegate that configures a <see cref="HoneycombOptions"/>.</param>


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- whitespace in cs files failing build

## Short description of the changes

- remove extra whitespace in `HoneycombOptions.cs` and `TracerProviderBuilderExtensions.cs`

