### PR TITLE
Fix build warnings

### DIFF
--- a/examples/netcoreapp2.1/netcoreapp2.1.csproj
+++ b/examples/netcoreapp2.1/netcoreapp2.1.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
+    <NoWarn>NETSDK1138</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Honeycomb.OpenTelemetry/Honeycomb.OpenTelemetry.csproj
+++ b/src/Honeycomb.OpenTelemetry/Honeycomb.OpenTelemetry.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net461;netcoreapp2.1</TargetFrameworks>
+    <NoWarn>NETSDK1138</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
     <!-- For SourceLink. See: https://github.com/dotnet/sourcelink#using-source-link-in-net-projects -->

--- a/test/Honeycomb.OpenTelemetry.Tests/Honeycomb.OpenTelemetry.Tests.csproj
+++ b/test/Honeycomb.OpenTelemetry.Tests/Honeycomb.OpenTelemetry.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
+    <NoWarn>NETSDK1138</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Fixes build warnings that netcoreapp2.1 is no longer supported. This is okay as we build a netcoreapp2.1 distributable for our glitch demos.

## Short description of the changes
- Add `nowarn` entries into each project that sets netcoreapp2.1 as a target framework

