### PR TITLE
fix: Fixed Redis auto-detection

### DIFF
--- a/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
+++ b/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
@@ -126,7 +126,7 @@ namespace Honeycomb.OpenTelemetry
         /// Requires that either <see cref="RedisConnection"/> is set, if you're not using a DI Container, or
         /// if you are using a DI Container, then it requires that an <see cref="IConnectionMultiplexer"/> has been registered with the <see cref="IServiceProvider"/>.
         /// </summary>
-        public bool InstrumentStackExchangeRedisClient { get; set; } = true;
+        public bool InstrumentStackExchangeRedisClient { get; set; }
 
         /// <summary>
         /// (Optional) Options delegate to configure HttpClient instrumentation.

--- a/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
+++ b/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
@@ -126,7 +126,7 @@ namespace Honeycomb.OpenTelemetry
         /// Requires that either <see cref="RedisConnection"/> is set, if you're not using a DI Container, or
         /// if you are using a DI Container, then it requires that an <see cref="IConnectionMultiplexer"/> has been registered with the <see cref="IServiceProvider"/>.
         /// </summary>
-        public bool InstrumentStackExchangeRedisClient { get; set; }
+        public bool InstrumentStackExchangeRedisClient { get; set; } = true;
 
         /// <summary>
         /// (Optional) Options delegate to configure HttpClient instrumentation.

--- a/src/Honeycomb.OpenTelemetry/ServiceCollectionExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry/ServiceCollectionExtensions.cs
@@ -41,6 +41,11 @@ namespace Honeycomb.OpenTelemetry
             services
                 .AddOpenTelemetryTracing(hostingBuilder => hostingBuilder.Configure(((serviceProvider, builder) =>
                     {
+                        if (options.RedisConnection == null && serviceProvider.GetService<IConnectionMultiplexer>() != null)
+                        {
+                            options.RedisConnection = serviceProvider.GetService<IConnectionMultiplexer>();
+                        }
+
                         builder
                             .AddHoneycomb(options)
                             .AddAspNetCoreInstrumentation(opts =>

--- a/src/Honeycomb.OpenTelemetry/TracerProviderBuilderExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry/TracerProviderBuilderExtensions.cs
@@ -82,10 +82,9 @@ namespace Honeycomb.OpenTelemetry
                 builder.AddSqlClientInstrumentation(options.ConfigureSqlClientInstrumentationOptions);
             }
 
-            if (options.InstrumentStackExchangeRedisClient)
+            if (options.InstrumentStackExchangeRedisClient && options.RedisConnection != null)
             {
-                builder.AddRedisInstrumentation(options.RedisConnection, // if null, resolved using the application IServiceProvider.
-                    options.ConfigureStackExchangeRedisClientInstrumentationOptions);
+                builder.AddRedisInstrumentation(options.RedisConnection, options.ConfigureStackExchangeRedisClientInstrumentationOptions);
             }
 
 #if NET461


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Closes #149 

## Short description of the changes

- In `HoneycombOptions.cs`, `InstrumentStackExchangeRedisClient` is defaulted to true which threw an error if Redis wasn't in use. `TracerProviderBuilderExtensions.cs` had a check `if (options.InstrumentStackExchangeRedisClient)`... but by having a default true, this check would always be true unless someone explicitly set it to false.
- This is now updated so it will still default to true for auto-instrumenting Redis, but additional checks are in place for existence of RedisConnection.
- This was confirmed to work both with IServiceCollection and HoneycombOptions.