### PR TITLE
parse missing command line arguments

### DIFF
--- a/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
+++ b/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
@@ -119,7 +119,7 @@ namespace Honeycomb.OpenTelemetry
         /// Controls whether to instrument GrpcClient calls when running on .NET Standard 2.1 or greater.
         /// Requires <see cref="InstrumentHttpClient" /> to be <see langword="true"/> due to the underlying implementation.
         /// </summary>
-        public bool InstrumentGprcClient { get; set; } = true;
+        public bool InstrumentGrpcClient { get; set; } = true;
 
         /// <summary>
         /// Controls whether the Stack Exchange Redis Client is instrumented.
@@ -150,7 +150,11 @@ namespace Honeycomb.OpenTelemetry
             {"--honeycomb-endpoint", "endpoint"},
             {"--honeycomb-samplerate", "samplerate"},
             {"--service-name", "servicename"},
-            {"--service-version", "serviceversion"}
+            {"--service-version", "serviceversion"},
+            {"--instrument-http", "instrumenthttpclient"},
+            {"--instrument-sql", "instrumentsqlclient"},
+            {"--instrument-grpc", "instrumentgrpcclient"},
+            {"--instrument-redis", "instrumentstackexchangeredisclient"}
         };
 
         /// <summary>

--- a/src/Honeycomb.OpenTelemetry/TracerProviderBuilderExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry/TracerProviderBuilderExtensions.cs
@@ -100,7 +100,7 @@ namespace Honeycomb.OpenTelemetry
 #endif
 
 #if NETSTANDARD2_1
-            if (options.InstrumentGprcClient && options.InstrumentHttpClient) // HttpClient needs to be instrumented for GrpcClient instrumentation to work.
+            if (options.InstrumentGrpcClient && options.InstrumentHttpClient) // HttpClient needs to be instrumented for GrpcClient instrumentation to work.
             {
                 // See https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Instrumentation.GrpcNetClient/README.md#suppressdownstreaminstrumentation
                 builder.AddGrpcClientInstrumentation(options => options.SuppressDownstreamInstrumentation = true);

--- a/test/Honeycomb.OpenTelemetry.Tests/HoneycombOptionsTests.cs
+++ b/test/Honeycomb.OpenTelemetry.Tests/HoneycombOptionsTests.cs
@@ -1,7 +1,7 @@
 using Microsoft.Extensions.Configuration;
 using Xunit;
 
-namespace Honeycomb.OpenTelemetry
+namespace Honeycomb.OpenTelemetry.Tests
 {
     public class HoneycombOptionsHelperTests
     {
@@ -9,15 +9,16 @@ namespace Honeycomb.OpenTelemetry
         public void CanParseOptionsFromSpacedCommandLineArgs()
         {
             var options = HoneycombOptions.FromArgs(
-                new string[]
-                {
-                    "--honeycomb-apikey", "my-apikey",
-                    "--honeycomb-dataset", "my-dataset",
-                    "--honeycomb-samplerate", "5",
-                    "--honeycomb-endpoint", "my-endpoint",
-                    "--service-name", "my-service",
-                    "--service-version", "my-version"
-                }
+                "--honeycomb-apikey", "my-apikey",
+                "--honeycomb-dataset", "my-dataset",
+                "--honeycomb-samplerate", "5",
+                "--honeycomb-endpoint", "my-endpoint",
+                "--service-name", "my-service",
+                "--service-version", "my-version",
+                "--instrument-http", "false",
+                "--instrument-sql", "false",
+                "--instrument-grpc", "false",
+                "--instrument-redis", "false"
             );
 
             Assert.Equal("my-apikey", options.ApiKey);
@@ -26,22 +27,26 @@ namespace Honeycomb.OpenTelemetry
             Assert.Equal("my-endpoint", options.Endpoint);
             Assert.Equal("my-service", options.ServiceName);
             Assert.Equal("my-version", options.ServiceVersion);
+            Assert.False(options.InstrumentHttpClient);
+            Assert.False(options.InstrumentSqlClient);
+            Assert.False(options.InstrumentGrpcClient);
+            Assert.False(options.InstrumentStackExchangeRedisClient);
         }
 
         [Fact]
         public void CanParseOptionsFromInlineCommandLineArgs()
         {
             var options = HoneycombOptions.FromArgs(
-                new string[]
-                {
-                    "--honeycomb-apikey=my-apikey",
-                    "--honeycomb-dataset=my-dataset",
-                    "--honeycomb-samplerate=5",
-                    "--honeycomb-endpoint=my-endpoint",
-                    "--service-name=my-service",
-                    "--service-version=my-version"
-                }
-            );
+                "--honeycomb-apikey=my-apikey",
+                "--honeycomb-dataset=my-dataset",
+                "--honeycomb-samplerate=5",
+                "--honeycomb-endpoint=my-endpoint",
+                "--service-name=my-service",
+                "--service-version=my-version",
+                "--instrument-http=false",
+                "--instrument-sql=false",
+                "--instrument-grpc=false",
+                "--instrument-redis=false");
 
             Assert.Equal("my-apikey", options.ApiKey);
             Assert.Equal("my-dataset", options.Dataset);
@@ -49,18 +54,22 @@ namespace Honeycomb.OpenTelemetry
             Assert.Equal("my-endpoint", options.Endpoint);
             Assert.Equal("my-service", options.ServiceName);
             Assert.Equal("my-version", options.ServiceVersion);
+            Assert.False(options.InstrumentHttpClient);
+            Assert.False(options.InstrumentSqlClient);
+            Assert.False(options.InstrumentGrpcClient);
+            Assert.False(options.InstrumentStackExchangeRedisClient);
         }
 
         [Fact]
         public void CanParseOptionsFromConfiguration()
         {
-            var options = 
-                new ConfigurationBuilder()
-                    .AddJsonFile("appsettings.test.json")
-                    .Build()
-                    .GetSection(HoneycombOptions.ConfigSectionName)
-                    .Get<HoneycombOptions>()
-            ;
+            var options =
+                    new ConfigurationBuilder()
+                        .AddJsonFile("appsettings.test.json")
+                        .Build()
+                        .GetSection(HoneycombOptions.ConfigSectionName)
+                        .Get<HoneycombOptions>()
+                ;
 
             Assert.Equal("my-apikey", options.ApiKey);
             Assert.Equal("my-dataset", options.Dataset);
@@ -68,6 +77,10 @@ namespace Honeycomb.OpenTelemetry
             Assert.Equal("my-endpoint", options.Endpoint);
             Assert.Equal("my-service", options.ServiceName);
             Assert.Equal("my-version", options.ServiceVersion);
+            Assert.False(options.InstrumentHttpClient);
+            Assert.False(options.InstrumentSqlClient);
+            Assert.False(options.InstrumentGrpcClient);
+            Assert.False(options.InstrumentStackExchangeRedisClient);
         }
     }
 }

--- a/test/Honeycomb.OpenTelemetry.Tests/appsettings.test.json
+++ b/test/Honeycomb.OpenTelemetry.Tests/appsettings.test.json
@@ -5,6 +5,10 @@
     "SampleRate": 5,
     "Endpoint": "my-endpoint",
     "ServiceName": "my-service",
-    "ServiceVersion": "my-version"
+    "ServiceVersion": "my-version",
+    "InstrumentHttpClient": false,
+    "InstrumentSqlClient": "false",
+    "InstrumentGrpcClient": false,
+    "InstrumentStackExchangeRedisClient": "false"
   }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- the enable instrumentation arguments were not parsed by command line

## Short description of the changes

- mostly tests and adding instrumentation args to the command line map
- fixed the typo in gRPC -- technically a breaking change

