### PR TITLE
bug: trace extension should use trace config

### DIFF
--- a/src/Honeycomb.OpenTelemetry/TracerProviderBuilderExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry/TracerProviderBuilderExtensions.cs
@@ -35,18 +35,18 @@ namespace Honeycomb.OpenTelemetry
         /// </summary>
         public static TracerProviderBuilder AddHoneycomb(this TracerProviderBuilder builder, HoneycombOptions options)
         {
-            if (string.IsNullOrWhiteSpace(options.ApiKey))
-                throw new ArgumentException("API key cannot be empty");
-            if (string.IsNullOrWhiteSpace(options.Dataset))
-                throw new ArgumentException("Dataset cannot be empty");
+            if (string.IsNullOrWhiteSpace(options.TracesApiKey))
+                throw new ArgumentException("Traces API key cannot be empty");
+            if (string.IsNullOrWhiteSpace(options.TracesDataset))
+                throw new ArgumentException("Traces dataset cannot be empty");
 
             builder
                 .AddSource(options.ServiceName)
                 .SetSampler(new DeterministicSampler(options.SampleRate))
                 .AddOtlpExporter(otlpOptions =>
                 {
-                    otlpOptions.Endpoint = new Uri(options.Endpoint);
-                    otlpOptions.Headers = string.Format("x-honeycomb-team={0},x-honeycomb-dataset={1}", options.ApiKey, options.Dataset);
+                    otlpOptions.Endpoint = new Uri(options.TracesEndpoint);
+                    otlpOptions.Headers = $"x-honeycomb-team={options.TracesApiKey},x-honeycomb-dataset={options.TracesDataset}";
                 })
                 .SetResourceBuilder(
                     ResourceBuilder


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- missed a spot when implementing #146  -- trace provider builder was still using fallback options, instead of trace-specific options

## Short description of the changes

-

