### PR TITLE
Make API key and dataset optional

### DIFF
--- a/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
+++ b/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
@@ -73,7 +73,6 @@ namespace Honeycomb.OpenTelemetry
         /// <summary>
         /// API key used to send telemetry data to Honeycomb.
         /// <para/>
-        /// <b>Required</b>
         /// </summary>
         public string ApiKey { get; set; }
 
@@ -98,7 +97,6 @@ namespace Honeycomb.OpenTelemetry
         /// <summary>
         /// Honeycomb dataset to store telemetry data.
         /// <para/>
-        /// <b>Required</b>
         /// </summary>
         public string Dataset { get; set; }
 

--- a/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
+++ b/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
@@ -209,7 +209,7 @@ namespace Honeycomb.OpenTelemetry
         /// </summary>
         public List<string> MeterNames { get; set; } = new List<string>();
 
-        private static Dictionary<string, string> _commandLineSwitchMap = new Dictionary<string, string>
+        private static readonly Dictionary<string, string> CommandLineSwitchMap = new Dictionary<string, string>
         {
             { "--honeycomb-apikey", "apikey" },
             { "--honeycomb-traces-apikey", "tracesapikey" },
@@ -236,7 +236,7 @@ namespace Honeycomb.OpenTelemetry
         public static HoneycombOptions FromArgs(params string[] args)
         {
             var config = new ConfigurationBuilder()
-                .AddCommandLine(args, _commandLineSwitchMap)
+                .AddCommandLine(args, CommandLineSwitchMap)
                 .Build();
             var honeycombOptions = config
                 .Get<HoneycombOptions>();

--- a/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
+++ b/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
@@ -16,13 +16,12 @@ namespace Honeycomb.OpenTelemetry
     /// </summary>
     public class HoneycombOptions
     {
-        private static readonly string s_defaultServiceName = "{unknown_service_name}";
-        private static readonly string s_defaultServiceVersion = "{unknown_service_version}";
+        private static readonly string SDefaultServiceName = "{unknown_service_name}";
+        private static readonly string SDefaultServiceVersion = "{unknown_service_version}";
 
         private string _tracesApiKey;
         private string _metricsApiKey;
         private string _tracesDataset;
-        private string _metricsDataset;
         private string _tracesEndpoint;
         private string _metricsEndpoint;
 
@@ -49,8 +48,8 @@ namespace Honeycomb.OpenTelemetry
 #endif
             if (assembly != null)
             {
-                s_defaultServiceName = assembly.GetName().Name;
-                s_defaultServiceVersion =
+                SDefaultServiceName = assembly.GetName().Name;
+                SDefaultServiceVersion =
                     assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ??
                     assembly.GetCustomAttribute<AssemblyFileVersionAttribute>()?.Version;
             }
@@ -79,7 +78,7 @@ namespace Honeycomb.OpenTelemetry
         public string ApiKey { get; set; }
 
         /// <summary>
-        /// API key used to send trace telemtry data to Honeycomb. Defaults to <see cref="ApiKey"/>.
+        /// API key used to send trace telemetry data to Honeycomb. Defaults to <see cref="ApiKey"/>.
         /// </summary>
         public string TracesApiKey
         {
@@ -88,7 +87,7 @@ namespace Honeycomb.OpenTelemetry
         }
 
         /// <summary>
-        /// API key used to send metrics telemtry data to Honeycomb. Defaults to <see cref="ApiKey"/>.
+        /// API key used to send metrics telemetry data to Honeycomb. Defaults to <see cref="ApiKey"/>.
         /// </summary>
         public string MetricsApiKey
         {
@@ -118,11 +117,7 @@ namespace Honeycomb.OpenTelemetry
         /// <para/>
         /// Required to enable metrics.
         /// </summary>        
-        public string MetricsDataset
-        {
-            get { return _metricsDataset; }
-            set { _metricsDataset = value; }
-        }
+        public string MetricsDataset { get; set; }
 
         /// <summary>
         /// API endpoint to send telemetry data. Defaults to <see cref="DefaultEndpoint"/>.
@@ -158,12 +153,12 @@ namespace Honeycomb.OpenTelemetry
         /// <summary>
         /// Service name used to identify application. Defaults to application assembly name.
         /// </summary>
-        public string ServiceName { get; set; } = s_defaultServiceName;
+        public string ServiceName { get; set; } = SDefaultServiceName;
 
         /// <summary>
         /// Service version. Defaults to application assembly information version.
         /// </summary>
-        public string ServiceVersion { get; set; } = s_defaultServiceVersion;
+        public string ServiceVersion { get; set; } = SDefaultServiceVersion;
 
         /// <summary>
         /// Redis <see cref="IConnectionMultiplexer"/>. Set this if you aren't using a DI Container.
@@ -216,7 +211,7 @@ namespace Honeycomb.OpenTelemetry
         /// </summary>
         public List<string> MeterNames { get; set; } = new List<string>();
 
-        private static Dictionary<string, string> CommandLineSwitchMap = new Dictionary<string, string>
+        private static Dictionary<string, string> _commandLineSwitchMap = new Dictionary<string, string>
         {
             { "--honeycomb-apikey", "apikey" },
             { "--honeycomb-traces-apikey", "tracesapikey" },
@@ -243,7 +238,7 @@ namespace Honeycomb.OpenTelemetry
         public static HoneycombOptions FromArgs(params string[] args)
         {
             var config = new ConfigurationBuilder()
-                .AddCommandLine(args, CommandLineSwitchMap)
+                .AddCommandLine(args, _commandLineSwitchMap)
                 .Build();
             var honeycombOptions = config
                 .Get<HoneycombOptions>();

--- a/src/Honeycomb.OpenTelemetry/MeterProviderBuilderExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry/MeterProviderBuilderExtensions.cs
@@ -49,7 +49,8 @@ namespace Honeycomb.OpenTelemetry
                     .AddOtlpExporter(otlpOptions =>
                     {
                         otlpOptions.Endpoint = new Uri(options.MetricsEndpoint);
-                        if (!string.IsNullOrWhiteSpace(options.MetricsApiKey))
+                        if (!string.IsNullOrWhiteSpace(options.MetricsApiKey) &&
+                            !string.IsNullOrWhiteSpace(options.MetricsDataset))
                             otlpOptions.Headers =
                                 $"x-honeycomb-team={options.MetricsApiKey},x-honeycomb-dataset={options.MetricsDataset}";
                     });

--- a/src/Honeycomb.OpenTelemetry/MeterProviderBuilderExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry/MeterProviderBuilderExtensions.cs
@@ -20,7 +20,8 @@ namespace Honeycomb.OpenTelemetry
         /// <summary>
         /// Configures the <see cref="MeterProviderBuilder"/> to send metrics telemetry data to Honeycomb.
         /// </summary>
-        public static MeterProviderBuilder AddHoneycomb(this MeterProviderBuilder builder, Action<HoneycombOptions> configureHoneycombOptions = null)
+        public static MeterProviderBuilder AddHoneycomb(this MeterProviderBuilder builder,
+            Action<HoneycombOptions> configureHoneycombOptions = null)
         {
             var honeycombOptions = new HoneycombOptions();
             configureHoneycombOptions?.Invoke(honeycombOptions);
@@ -35,6 +36,8 @@ namespace Honeycomb.OpenTelemetry
             // only enable metrics if a metrics dataset is set
             if (!string.IsNullOrWhiteSpace(options.MetricsDataset))
             {
+                if (string.IsNullOrWhiteSpace(options.MetricsApiKey))
+                    Console.WriteLine("WARN: missing metrics API key");
                 builder
                     .SetResourceBuilder(
                         ResourceBuilder
@@ -46,7 +49,9 @@ namespace Honeycomb.OpenTelemetry
                     .AddOtlpExporter(otlpOptions =>
                     {
                         otlpOptions.Endpoint = new Uri(options.MetricsEndpoint);
-                        otlpOptions.Headers = $"x-honeycomb-team={options.MetricsApiKey},x-honeycomb-dataset={options.MetricsDataset}";
+                        if (!string.IsNullOrWhiteSpace(options.MetricsApiKey))
+                            otlpOptions.Headers =
+                                $"x-honeycomb-team={options.MetricsApiKey},x-honeycomb-dataset={options.MetricsDataset}";
                     });
 
                 builder.AddMeter(options.ServiceName);
@@ -55,6 +60,7 @@ namespace Honeycomb.OpenTelemetry
                     builder.AddMeter(meterName);
                 }
             }
+
             return builder;
         }
     }


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- allow using the distro with a collector, where API key and dataset is configured in the collector config
- closes #160 

## Short description of the changes

- most of the diff is formatting, if there's any unfavorable changes LMK and I will update editorconfig
- write a warning to the console when API key or dataset is not configured, don't configure OTLP exporter headers if they're missing
- NOTE: in my testing, the previous `ArgumentException` was swallowed, so it would just silently not configure the exporter

