### PR TITLE
remove parent-based sampler

### DIFF
--- a/src/Honeycomb.OpenTelemetry/DeterministicSampler.cs
+++ b/src/Honeycomb.OpenTelemetry/DeterministicSampler.cs
@@ -47,7 +47,7 @@ namespace Honeycomb.OpenTelemetry
                     ratio = AlwaysSampleRatio / sampleRate;
                     break;
             }
-            _innerSampler = new ParentBasedSampler(new TraceIdRatioBasedSampler(ratio));
+            _innerSampler = new TraceIdRatioBasedSampler(ratio);
             _sampleResultAttributes = new List<KeyValuePair<string, object>>
             {
                 new KeyValuePair<string, object>(SampleRateField, sampleRate)


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- parent-based sampler would not work because we need to know what `SampleRate` to set
- closes #163 

## Short description of the changes

- meow

