### PR TITLE
Validate that HoneycombOptions exists before we do anything

### DIFF
--- a/src/Honeycomb.OpenTelemetry/TracerProviderBuilderExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry/TracerProviderBuilderExtensions.cs
@@ -41,6 +41,11 @@ namespace Honeycomb.OpenTelemetry
         /// </summary>
         public static TracerProviderBuilder AddHoneycomb(this TracerProviderBuilder builder, HoneycombOptions options)
         {
+            if (options is null)
+            {
+                throw new ArgumentNullException(nameof(options), "No Honeycomb options have been set in appsettings.json, environment variables, or the command line.");
+            }
+            
             if (string.IsNullOrWhiteSpace(options.TracesApiKey))
                 Console.WriteLine("WARN: missing traces API key");
             if (string.IsNullOrWhiteSpace(options.TracesDataset))


### PR DESCRIPTION
Found this with @jessitron who was having fun with .NET and ran into this issue!

The scenario is:

* Someone wants to do otel with us
* They add the package
* They get coding, IntelliSense, whee
* They run it
* They get a nasty exception with no information at all
* The reason is they haven't set any config options at all, and `HoneycombOptions` is `null`