### PR TITLE
Support specifying resource attributes

### DIFF
--- a/examples/aspnetcore/appsettings.json
+++ b/examples/aspnetcore/appsettings.json
@@ -11,6 +11,10 @@
     "ServiceName": "my-web-app",
     "ApiKey": "{apikey}",
     "TracesDataset": "{traces-dataset}",
-    "MetricsDataset": "{metrics-dataset}"
+    "MetricsDataset": "{metrics-dataset}",
+    "AdditionalResources": {
+      "toot": "McGoot",
+      "number":  1234
+    }
   }
 }

--- a/examples/aspnetcore/appsettings.json
+++ b/examples/aspnetcore/appsettings.json
@@ -8,11 +8,10 @@
   },
   "AllowedHosts": "*",
   "Honeycomb": {
-    "ServiceName": "my-web-app",
     "ApiKey": "{apikey}",
     "TracesDataset": "{traces-dataset}",
     "MetricsDataset": "{metrics-dataset}",
-    "AdditionalResources": {
+    "ResourceAttributes": {
       "toot": "McGoot",
       "number":  1234
     }

--- a/examples/console/Program.cs
+++ b/examples/console/Program.cs
@@ -18,6 +18,9 @@ namespace console
                 MetricsDataset = "{metrics-dataset}" // optional
             };
 
+            // You can also pull configuration from .NET command-line arguments
+            var options2 = HoneycombOptions.FromArgs(args);
+
             // ------------ TRACES ------------
 
             // configure OpenTelemetry SDK to send trace data to Honeycomb

--- a/examples/console/Properties/launchSettings.json
+++ b/examples/console/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "console": {
+      "commandName": "Project",
+      "commandLineArgs": "--additional-resource-attributes \"toot: MgGoot, numbers:123\""
+    }
+  }
+}

--- a/examples/console/Properties/launchSettings.json
+++ b/examples/console/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "console": {
       "commandName": "Project",
-      "commandLineArgs": "--additional-resource-attributes \"toot: MgGoot, numbers:123\""
+      "commandLineArgs": "--resource-attributes \"toot: MgGoot, numbers:123\""
     }
   }
 }

--- a/src/Honeycomb.OpenTelemetry/Extensions.cs
+++ b/src/Honeycomb.OpenTelemetry/Extensions.cs
@@ -4,7 +4,7 @@ namespace Honeycomb.OpenTelemetry
 {
     internal static class StringExtensions
     {
-        internal static object ToValueAsObject(this string str)
+        internal static object ToHoneycombType(this string str)
         {
             if (int.TryParse(str, out int intVal))
             {

--- a/src/Honeycomb.OpenTelemetry/Extensions.cs
+++ b/src/Honeycomb.OpenTelemetry/Extensions.cs
@@ -1,0 +1,31 @@
+using System;
+
+namespace Honeycomb.OpenTelemetry
+{
+    internal static class StringExtensions
+    {
+        internal static object ToValueAsObject(this string str)
+        {
+            if (int.TryParse(str, out int intVal))
+            {
+                return intVal;
+            }
+            else if (double.TryParse(str, out double doubleVal))
+            {
+                return doubleVal;
+            }
+            else if (bool.TryParse(str, out bool boolVal))
+            {
+                return boolVal;
+            }
+            else if (DateTimeOffset.TryParse(str, out DateTimeOffset dateTimeVal))
+            {
+                return dateTimeVal;
+            }
+            else
+            {
+                return str;
+            }
+        }
+    }
+}

--- a/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
+++ b/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
@@ -265,9 +265,14 @@ namespace Honeycomb.OpenTelemetry
                     // Example: "abc:123" --> dict.Add("abc", 123)
                     // ...we need to do this ugly stuff because of the net461 target.
                     // ...if/when we can drop that, this can be cleaned up considerably
-                    dict.Add(
-                        mapping.Substring(0, mapping.IndexOf(':')).Trim(),
-                        mapping.Substring(mapping.IndexOf(':') + 1, mapping.Length - 1 - mapping.IndexOf(':')).Trim());
+                    var key = mapping.Substring(0, mapping.IndexOf(':')).Trim();
+                    var value =
+                        mapping
+                        .Substring(mapping.IndexOf(':') + 1, mapping.Length - 1 - mapping.IndexOf(':'))
+                        .Trim()
+                        .ToValueAsObject();
+
+                    dict.Add(key, value);
                 }
 
                 honeycombOptions.AdditionalResources = dict;

--- a/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
+++ b/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
@@ -234,7 +234,7 @@ namespace Honeycomb.OpenTelemetry
             { "--instrument-grpc", "instrumentgrpcclient" },
             { "--instrument-redis", "instrumentstackexchangeredisclient" },
             { "--meter-names", "meternames" },
-            { "--additional-resource-attributes", "additionalresourceattributes" }
+            { "--resource-attributes", "additionalresourceattributes" }
         };
 
         /// <summary>

--- a/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
+++ b/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
@@ -270,7 +270,7 @@ namespace Honeycomb.OpenTelemetry
                         mapping
                         .Substring(mapping.IndexOf(':') + 1, mapping.Length - 1 - mapping.IndexOf(':'))
                         .Trim()
-                        .ToValueAsObject();
+                        .ToHoneycombType();
 
                     dict.Add(key, value);
                 }

--- a/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
+++ b/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
@@ -213,7 +213,7 @@ namespace Honeycomb.OpenTelemetry
         /// <summary>
         /// (Optional) Additional OpenTelemetry Resource Attributes a user can configure.
         /// </summary>
-        public Dictionary<string, object> AdditionalResources { get; set; } = new Dictionary<string, object>();
+        public Dictionary<string, object> ResourceAttributes { get; set; } = new Dictionary<string, object>();
 
         private static readonly Dictionary<string, string> CommandLineSwitchMap = new Dictionary<string, string>
         {
@@ -275,7 +275,7 @@ namespace Honeycomb.OpenTelemetry
                     dict.Add(key, value);
                 }
 
-                honeycombOptions.AdditionalResources = dict;
+                honeycombOptions.ResourceAttributes = dict;
             }
 
             return honeycombOptions;

--- a/src/Honeycomb.OpenTelemetry/MeterProviderBuilderExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry/MeterProviderBuilderExtensions.cs
@@ -42,7 +42,7 @@ namespace Honeycomb.OpenTelemetry
                     .SetResourceBuilder(
                         ResourceBuilder
                             .CreateDefault()
-                            .AddHoneycombAttributes()
+                            .AddResourceAttributes(options)
                             .AddEnvironmentVariableDetector()
                             .AddService(serviceName: options.ServiceName, serviceVersion: options.ServiceVersion)
                     )

--- a/src/Honeycomb.OpenTelemetry/ResourceBuilderExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry/ResourceBuilderExtensions.cs
@@ -13,9 +13,10 @@ namespace Honeycomb.OpenTelemetry
         /// <summary>
         /// Configures the <see cref="ResourceBuilder"/> with Honeycomb attributes.
         /// </summary>
-        public static ResourceBuilder AddHoneycombAttributes(this ResourceBuilder builder)
+        public static ResourceBuilder AddResourceAttributes(this ResourceBuilder builder, HoneycombOptions options)
         {
             return builder
+                .AddAttributes(options.ResourceAttributes)
                 .AddAttributes(new List<KeyValuePair<string, object>>
                 {
                     new KeyValuePair<string, object>("honeycomb.distro.language", "dotnet"),
@@ -23,14 +24,6 @@ namespace Honeycomb.OpenTelemetry
                     new KeyValuePair<string, object>("honeycomb.distro.runtime_version",
                         Environment.Version.ToString()),
                 });
-        }
-
-        /// <summary>
-        /// Configures the <see cref="ResourceBuilder"/> with additional, user-provided resource attributes.
-        /// </summary>
-        public static ResourceBuilder AddAdditionalAttributes(this ResourceBuilder builder, HoneycombOptions options)
-        {
-            return builder.AddAttributes(options.ResourceAttributes);
         }
 
         private static string GetFileVersion()

--- a/src/Honeycomb.OpenTelemetry/ResourceBuilderExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry/ResourceBuilderExtensions.cs
@@ -25,6 +25,14 @@ namespace Honeycomb.OpenTelemetry
                 });
         }
 
+        /// <summary>
+        /// Configures the <see cref="ResourceBuilder"/> with additional, user-provided resource attributes.
+        /// </summary>
+        public static ResourceBuilder AddAdditionalAttributes(this ResourceBuilder builder, HoneycombOptions options)
+        {
+            return builder.AddAttributes(options.AdditionalResources);
+        }
+
         private static string GetFileVersion()
         {
             var version = typeof(ResourceBuilderExtensions)

--- a/src/Honeycomb.OpenTelemetry/ResourceBuilderExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry/ResourceBuilderExtensions.cs
@@ -30,7 +30,7 @@ namespace Honeycomb.OpenTelemetry
         /// </summary>
         public static ResourceBuilder AddAdditionalAttributes(this ResourceBuilder builder, HoneycombOptions options)
         {
-            return builder.AddAttributes(options.AdditionalResources);
+            return builder.AddAttributes(options.ResourceAttributes);
         }
 
         private static string GetFileVersion()

--- a/src/Honeycomb.OpenTelemetry/ServiceCollectionExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry/ServiceCollectionExtensions.cs
@@ -35,7 +35,7 @@ namespace Honeycomb.OpenTelemetry
             // This is to make account for the fact that ASP.NET Core parses values from configuration
             // out as strings. Strings are fun, but Honeycomb has a type system and we should respect that instead.
             var resources = new Dictionary<string, object>();
-            foreach (var kvp in options.AdditionalResources)
+            foreach (var kvp in options.ResourceAttributes)
             {
                 var value = kvp.Value as string;
                 if (value is null)
@@ -48,7 +48,7 @@ namespace Honeycomb.OpenTelemetry
                 }
             }
 
-            options.AdditionalResources = resources;
+            options.ResourceAttributes = resources;
 
             return services.AddHoneycomb(options);
         }

--- a/src/Honeycomb.OpenTelemetry/TracerProviderBuilderExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry/TracerProviderBuilderExtensions.cs
@@ -61,6 +61,7 @@ namespace Honeycomb.OpenTelemetry
                     ResourceBuilder
                         .CreateDefault()
                         .AddHoneycombAttributes()
+                        .AddAdditionalAttributes(options)
                         .AddEnvironmentVariableDetector()
                         .AddService(serviceName: options.ServiceName, serviceVersion: options.ServiceVersion)
                 )

--- a/src/Honeycomb.OpenTelemetry/TracerProviderBuilderExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry/TracerProviderBuilderExtensions.cs
@@ -60,8 +60,7 @@ namespace Honeycomb.OpenTelemetry
                 .SetResourceBuilder(
                     ResourceBuilder
                         .CreateDefault()
-                        .AddHoneycombAttributes()
-                        .AddAdditionalAttributes(options)
+                        .AddResourceAttributes(options)
                         .AddEnvironmentVariableDetector()
                         .AddService(serviceName: options.ServiceName, serviceVersion: options.ServiceVersion)
                 )

--- a/test/Honeycomb.OpenTelemetry.Tests/HoneycombOptionsTests.cs
+++ b/test/Honeycomb.OpenTelemetry.Tests/HoneycombOptionsTests.cs
@@ -118,6 +118,30 @@ namespace Honeycomb.OpenTelemetry.Tests
             Assert.False(options.InstrumentStackExchangeRedisClient);
         }
 
+        [Theory]
+        [InlineData("toot:MgGoot, numbers:123")]
+        [InlineData("toot:MgGoot,numbers:123")]
+        [InlineData("toot: MgGoot,numbers: 123")]
+        [InlineData("toot: MgGoot, numbers: 123")]
+        [InlineData(" toot: MgGoot, numbers: 123")]
+        [InlineData(" toot: MgGoot,numbers: 123")]
+        [InlineData(" toot : MgGoot,numbers : 123 ")]
+        public void CanParseResourceAttributes(string attrs)
+        {
+            var options = HoneycombOptions.FromArgs(
+                "--honeycomb-apikey", "my-apikey",
+                "--additional-resource-attributes", $"{attrs}");
+
+            Assert.Equal(new Dictionary<string, object> { { "toot", "MgGoot" }, { "numbers", 123 } }, options.AdditionalResources);
+
+
+            var options2 = HoneycombOptions.FromArgs(
+                "--honeycomb-apikey=my-apikey",
+                $"--additional-resource-attributes={attrs}");
+
+            Assert.Equal(new Dictionary<string, object> { { "toot", "MgGoot" }, { "numbers", 123 } }, options2.AdditionalResources);
+        }
+
         [Fact]
         public void CanParseOptionsFromConfiguration()
         {

--- a/test/Honeycomb.OpenTelemetry.Tests/HoneycombOptionsTests.cs
+++ b/test/Honeycomb.OpenTelemetry.Tests/HoneycombOptionsTests.cs
@@ -52,7 +52,7 @@ namespace Honeycomb.OpenTelemetry.Tests
                 "--instrument-sql", "false",
                 "--instrument-grpc", "false",
                 "--instrument-redis", "false",
-                "--additional-resource-attributes", "toot: MgGoot, numbers:123"
+                "--resource-attributes", "toot: MgGoot, numbers:123"
             );
 
             Assert.Equal("my-apikey", options.ApiKey);
@@ -96,7 +96,7 @@ namespace Honeycomb.OpenTelemetry.Tests
                 "--instrument-sql=false",
                 "--instrument-grpc=false",
                 "--instrument-redis=false",
-                "--additional-resource-attributes=toot: MgGoot, numbers:123");
+                "--resource-attributes=toot: MgGoot, numbers:123");
 
             Assert.Equal("my-apikey", options.ApiKey);
             Assert.Equal("my-traces-apikey", options.TracesApiKey);
@@ -130,14 +130,14 @@ namespace Honeycomb.OpenTelemetry.Tests
         {
             var options = HoneycombOptions.FromArgs(
                 "--honeycomb-apikey", "my-apikey",
-                "--additional-resource-attributes", $"{attrs}");
+                "--resource-attributes", $"{attrs}");
 
             Assert.Equal(new Dictionary<string, object> { { "toot", "MgGoot" }, { "numbers", 123 } }, options.ResourceAttributes);
 
 
             var options2 = HoneycombOptions.FromArgs(
                 "--honeycomb-apikey=my-apikey",
-                $"--additional-resource-attributes={attrs}");
+                $"--resource-attributes={attrs}");
 
             Assert.Equal(new Dictionary<string, object> { { "toot", "MgGoot" }, { "numbers", 123 } }, options2.ResourceAttributes);
         }

--- a/test/Honeycomb.OpenTelemetry.Tests/HoneycombOptionsTests.cs
+++ b/test/Honeycomb.OpenTelemetry.Tests/HoneycombOptionsTests.cs
@@ -51,7 +51,8 @@ namespace Honeycomb.OpenTelemetry.Tests
                 "--instrument-http", "false",
                 "--instrument-sql", "false",
                 "--instrument-grpc", "false",
-                "--instrument-redis", "false"
+                "--instrument-redis", "false",
+                "--additional-resource-attributes", "toot: MgGoot, numbers:123"
             );
 
             Assert.Equal("my-apikey", options.ApiKey);
@@ -67,6 +68,7 @@ namespace Honeycomb.OpenTelemetry.Tests
             Assert.Equal("my-service", options.ServiceName);
             Assert.Equal("my-version", options.ServiceVersion);
             Assert.Equal(new List<string> { "meter1", "meter2" }, options.MeterNames);
+            Assert.Equal(new Dictionary<string, object> {{"toot", "MgGoot"}, {"numbers", 123}}, options.AdditionalResources);
             Assert.False(options.InstrumentHttpClient);
             Assert.False(options.InstrumentSqlClient);
             Assert.False(options.InstrumentGrpcClient);
@@ -93,7 +95,8 @@ namespace Honeycomb.OpenTelemetry.Tests
                 "--instrument-http=false",
                 "--instrument-sql=false",
                 "--instrument-grpc=false",
-                "--instrument-redis=false");
+                "--instrument-redis=false",
+                "--additional-resource-attributes=toot: MgGoot, numbers:123");
 
             Assert.Equal("my-apikey", options.ApiKey);
             Assert.Equal("my-traces-apikey", options.TracesApiKey);
@@ -108,6 +111,7 @@ namespace Honeycomb.OpenTelemetry.Tests
             Assert.Equal("my-service", options.ServiceName);
             Assert.Equal("my-version", options.ServiceVersion);
             Assert.Equal(new List<string> { "meter1", "meter2" }, options.MeterNames);
+            Assert.Equal(new Dictionary<string, object> {{"toot", "MgGoot"}, {"numbers", 123}}, options.AdditionalResources);
             Assert.False(options.InstrumentHttpClient);
             Assert.False(options.InstrumentSqlClient);
             Assert.False(options.InstrumentGrpcClient);

--- a/test/Honeycomb.OpenTelemetry.Tests/HoneycombOptionsTests.cs
+++ b/test/Honeycomb.OpenTelemetry.Tests/HoneycombOptionsTests.cs
@@ -68,7 +68,7 @@ namespace Honeycomb.OpenTelemetry.Tests
             Assert.Equal("my-service", options.ServiceName);
             Assert.Equal("my-version", options.ServiceVersion);
             Assert.Equal(new List<string> { "meter1", "meter2" }, options.MeterNames);
-            Assert.Equal(new Dictionary<string, object> {{"toot", "MgGoot"}, {"numbers", 123}}, options.AdditionalResources);
+            Assert.Equal(new Dictionary<string, object> {{"toot", "MgGoot"}, {"numbers", 123}}, options.ResourceAttributes);
             Assert.False(options.InstrumentHttpClient);
             Assert.False(options.InstrumentSqlClient);
             Assert.False(options.InstrumentGrpcClient);
@@ -111,7 +111,7 @@ namespace Honeycomb.OpenTelemetry.Tests
             Assert.Equal("my-service", options.ServiceName);
             Assert.Equal("my-version", options.ServiceVersion);
             Assert.Equal(new List<string> { "meter1", "meter2" }, options.MeterNames);
-            Assert.Equal(new Dictionary<string, object> {{"toot", "MgGoot"}, {"numbers", 123}}, options.AdditionalResources);
+            Assert.Equal(new Dictionary<string, object> {{"toot", "MgGoot"}, {"numbers", 123}}, options.ResourceAttributes);
             Assert.False(options.InstrumentHttpClient);
             Assert.False(options.InstrumentSqlClient);
             Assert.False(options.InstrumentGrpcClient);
@@ -132,14 +132,14 @@ namespace Honeycomb.OpenTelemetry.Tests
                 "--honeycomb-apikey", "my-apikey",
                 "--additional-resource-attributes", $"{attrs}");
 
-            Assert.Equal(new Dictionary<string, object> { { "toot", "MgGoot" }, { "numbers", 123 } }, options.AdditionalResources);
+            Assert.Equal(new Dictionary<string, object> { { "toot", "MgGoot" }, { "numbers", 123 } }, options.ResourceAttributes);
 
 
             var options2 = HoneycombOptions.FromArgs(
                 "--honeycomb-apikey=my-apikey",
                 $"--additional-resource-attributes={attrs}");
 
-            Assert.Equal(new Dictionary<string, object> { { "toot", "MgGoot" }, { "numbers", 123 } }, options2.AdditionalResources);
+            Assert.Equal(new Dictionary<string, object> { { "toot", "MgGoot" }, { "numbers", 123 } }, options2.ResourceAttributes);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/honeycombio/honeycomb-opentelemetry-dotnet/issues/85

You can use it either as:

* appsetting.json, as the sample shows
* From commandline with `--additional-resource-attributes toot:McGoot, numbers:123` (with various degrees of spacing)

I tested this locally and against Honeycomb. You can see a representative trace here: https://ui-dogfood.honeycomb.io/prod/datasets/phillip-dotnet-test/result/bpgqpkM5Ah6/trace/jFvPyN3WkGz?span=0e0745641af78a7e

You'll note that there are two defined resource attributes, and both are present in the spans _and_ follow honeycomb's type system.