### PR TITLE
feat: provide more feedback to users to help configure for use in E&S

### DIFF
--- a/src/Honeycomb.OpenTelemetry/EnvironmentOptions.cs
+++ b/src/Honeycomb.OpenTelemetry/EnvironmentOptions.cs
@@ -25,18 +25,18 @@ namespace Honeycomb.OpenTelemetry
             _environmentService = service;
         }
 
-        internal string ApiKey { get => GetEnvironmentVariable(ApiKeyKey); }
-        internal string TracesApiKey { get => GetEnvironmentVariable(TracesApiKeyKey, ApiKey); }
-        internal string MetricsApiKey { get => GetEnvironmentVariable(MetricsApiKeyKey, ApiKey); }
-        internal string Dataset { get => GetEnvironmentVariable(DatasetKey); }
-        internal string TracesDataset { get => GetEnvironmentVariable(TracesDatasetKey, Dataset); }
-        internal string MetricsDataset { get => GetEnvironmentVariable(MetricsDatasetKey); }
-        internal string ApiEndpoint { get => GetEnvironmentVariable(ApiEndpointKey, DefaultApiEndpoint); }
-        internal string TracesEndpoint { get => GetEnvironmentVariable(TracesEndpointKey, ApiEndpoint); }
-        internal string MetricsEndpoint { get => GetEnvironmentVariable(MetricsEndpointKey, ApiEndpoint); }
-        internal string ServiceName { get => GetEnvironmentVariable(ServiceNameKey); }
-        internal string ServiceVersion { get => GetEnvironmentVariable(ServiceVersionKey); }
-        internal uint SampleRate { get => uint.TryParse(GetEnvironmentVariable(SampleRateKey), out var sampleRate) ? sampleRate : DefaultSampleRate; }
+        internal string ApiKey => GetEnvironmentVariable(ApiKeyKey);
+        internal string TracesApiKey => GetEnvironmentVariable(TracesApiKeyKey, ApiKey);
+        internal string MetricsApiKey => GetEnvironmentVariable(MetricsApiKeyKey, ApiKey);
+        internal string Dataset => GetEnvironmentVariable(DatasetKey);
+        internal string TracesDataset => GetEnvironmentVariable(TracesDatasetKey, Dataset);
+        internal string MetricsDataset => GetEnvironmentVariable(MetricsDatasetKey);
+        internal string ApiEndpoint => GetEnvironmentVariable(ApiEndpointKey, DefaultApiEndpoint);
+        internal string TracesEndpoint => GetEnvironmentVariable(TracesEndpointKey, ApiEndpoint);
+        internal string MetricsEndpoint => GetEnvironmentVariable(MetricsEndpointKey, ApiEndpoint);
+        internal string ServiceName => GetEnvironmentVariable(ServiceNameKey);
+        internal string ServiceVersion => GetEnvironmentVariable(ServiceVersionKey);
+        internal uint SampleRate => uint.TryParse(GetEnvironmentVariable(SampleRateKey), out var sampleRate) ? sampleRate : DefaultSampleRate;
 
         private string GetEnvironmentVariable(string key, string defaultValue = "")
         {
@@ -49,7 +49,8 @@ namespace Honeycomb.OpenTelemetry
             return defaultValue;
         }
 
-        internal static string getErrorMessage(string humanKey, string key) {
+        internal static string GetErrorMessage(string humanKey, string key)
+        {
             return ($"Missing {humanKey}. Specify {key} environment variable, or the associated property in appsettings.json or the command line");
         }
     }

--- a/src/Honeycomb.OpenTelemetry/EnvironmentOptions.cs
+++ b/src/Honeycomb.OpenTelemetry/EnvironmentOptions.cs
@@ -5,8 +5,14 @@ namespace Honeycomb.OpenTelemetry
     internal class EnvironmentOptions
     {
         private const string ApiKeyKey = "HONEYCOMB_API_KEY";
+        private const string TracesApiKeyKey = "HONEYCOMB_TRACES_API_KEY";
+        private const string MetricsApiKeyKey = "HONEYCOMB_METRICS_API_KEY";
         private const string DatasetKey = "HONEYCOMB_DATASET";
+        private const string TracesDatasetKey = "HONEYCOMB_TRACES_DATASET";
+        private const string MetricsDatasetKey = "HONEYCOMB_METRICS_DATASET";
         private const string ApiEndpointKey = "HONEYCOMB_API_ENDPOINT";
+        private const string TracesEndpointKey = "HONEYCOMB_TRACES_ENDPOINT";
+        private const string MetricsEndpointKey = "HONEYCOMB_METRICS_ENDPOINT";
         private const string SampleRateKey = "HONEYCOMB_SAMPLE_RATE";
         private const string ServiceNameKey = "SERVICE_NAME";
         private const string ServiceVersionKey = "SERVICE_VERSION";
@@ -20,8 +26,14 @@ namespace Honeycomb.OpenTelemetry
         }
 
         internal string ApiKey { get => GetEnvironmentVariable(ApiKeyKey); }
-        internal string Dataset  { get => GetEnvironmentVariable(DatasetKey); }
+        internal string TracesApiKey { get => GetEnvironmentVariable(TracesApiKeyKey, ApiKey); }
+        internal string MetricsApiKey { get => GetEnvironmentVariable(MetricsApiKeyKey, ApiKey); }
+        internal string Dataset { get => GetEnvironmentVariable(DatasetKey); }
+        internal string TracesDataset { get => GetEnvironmentVariable(TracesDatasetKey, Dataset); }
+        internal string MetricsDataset { get => GetEnvironmentVariable(MetricsDatasetKey); }
         internal string ApiEndpoint { get => GetEnvironmentVariable(ApiEndpointKey, DefaultApiEndpoint); }
+        internal string TracesEndpoint { get => GetEnvironmentVariable(TracesEndpointKey, ApiEndpoint); }
+        internal string MetricsEndpoint { get => GetEnvironmentVariable(MetricsEndpointKey, ApiEndpoint); }
         internal string ServiceName { get => GetEnvironmentVariable(ServiceNameKey); }
         internal string ServiceVersion { get => GetEnvironmentVariable(ServiceVersionKey); }
         internal uint SampleRate { get => uint.TryParse(GetEnvironmentVariable(SampleRateKey), out var sampleRate) ? sampleRate : DefaultSampleRate; }
@@ -35,6 +47,10 @@ namespace Honeycomb.OpenTelemetry
             }
 
             return defaultValue;
+        }
+
+        public static string getErrorMessage(string humanKey, string key) {
+            return ($"Missing {humanKey}. Specify {key} environment variable, or the associated property in appsettings.json or the command line");
         }
     }
 }

--- a/src/Honeycomb.OpenTelemetry/EnvironmentOptions.cs
+++ b/src/Honeycomb.OpenTelemetry/EnvironmentOptions.cs
@@ -49,7 +49,7 @@ namespace Honeycomb.OpenTelemetry
             return defaultValue;
         }
 
-        public static string getErrorMessage(string humanKey, string key) {
+        internal static string getErrorMessage(string humanKey, string key) {
             return ($"Missing {humanKey}. Specify {key} environment variable, or the associated property in appsettings.json or the command line");
         }
     }

--- a/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
+++ b/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
@@ -128,7 +128,7 @@ namespace Honeycomb.OpenTelemetry
         public uint SampleRate { get; set; } = DefaultSampleRate;
 
         /// <summary>
-        /// Service name used to identify application. Defaults to application assembly name.
+        /// Service name used to identify application. Defaults to unknown_process:processname.
         /// </summary>
         public string ServiceName { get; set; } = SDefaultServiceName;
 

--- a/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
+++ b/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
@@ -16,7 +16,7 @@ namespace Honeycomb.OpenTelemetry
     /// </summary>
     public class HoneycombOptions
     {
-        private static readonly string SDefaultServiceName = "{unknown_service_name}";
+        private static readonly string SDefaultServiceName = "unknown_service";
         private static readonly string SDefaultServiceVersion = "{unknown_service_version}";
 
         private string _tracesApiKey;
@@ -25,34 +25,17 @@ namespace Honeycomb.OpenTelemetry
         private string _tracesEndpoint;
         private string _metricsEndpoint;
 
+        /// <summary>
+        /// Confirm whether api key is legacy
+        /// </summary>
+        public Boolean isLegacyKey() {
+            // legacy key has 32 characters
+            return _tracesApiKey.Length == 32;
+        }
+
         static HoneycombOptions()
         {
-            // This works for everything other than ASP.NET (non-core) web apps
-            // because they are loaded from an unmanaged COM source so
-            // assembly.GetEntryAssembly() returns null
-            var assembly = Assembly.GetEntryAssembly();
-
-#if NET461
-            // inspired from https://stackoverflow.com/a/6754205
-            // try to load the current HTTPContext and work out the assembly name & version
-            if (assembly == null && System.Web.HttpContext.Current?.ApplicationInstance != null)
-            {
-                var type = System.Web.HttpContext.Current.ApplicationInstance.GetType();
-                while (type != null && type.Namespace == "ASP")
-                {
-                    type = type.BaseType;
-                }
-
-                assembly = type?.Assembly;
-            }
-#endif
-            if (assembly != null)
-            {
-                SDefaultServiceName = assembly.GetName().Name;
-                SDefaultServiceVersion =
-                    assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ??
-                    assembly.GetCustomAttribute<AssemblyFileVersionAttribute>()?.Version;
-            }
+            SDefaultServiceName = SDefaultServiceName + ":" + System.Diagnostics.Process.GetCurrentProcess().ProcessName;
         }
 
         /// <summary>

--- a/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
+++ b/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
@@ -17,10 +17,10 @@ namespace Honeycomb.OpenTelemetry
     public class HoneycombOptions
     {
 
-    /// <summary>
-    /// Default service name if service name is not provided.
-    /// </summary>
-        public static readonly string SDefaultServiceName = "unknown_service:" + System.Diagnostics.Process.GetCurrentProcess().ProcessName;
+        /// <summary>
+        /// Default service name if service name is not provided.
+        /// </summary>
+        internal static readonly string SDefaultServiceName = "unknown_service:" + System.Diagnostics.Process.GetCurrentProcess().ProcessName;
         private static readonly string SDefaultServiceVersion = "{unknown_service_version}";
 
         private string _tracesApiKey;
@@ -51,12 +51,12 @@ namespace Honeycomb.OpenTelemetry
         public string ApiKey { get; set; }
 
         /// <summary>
-        /// Confirm whether api key is legacy
+        /// Returns whether <see cref="ApiKey"/> is a legacy key.
         /// </summary>
-        public Boolean isLegacyKey()
+        internal Boolean IsLegacyKey()
         {
             // legacy key has 32 characters
-            return ApiKey.Length == 32;
+            return ApiKey?.Length == 32;
         }
 
         /// <summary>

--- a/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
+++ b/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
@@ -16,7 +16,11 @@ namespace Honeycomb.OpenTelemetry
     /// </summary>
     public class HoneycombOptions
     {
-        private static readonly string SDefaultServiceName = "unknown_service:" + System.Diagnostics.Process.GetCurrentProcess().ProcessName;
+
+    /// <summary>
+    /// Default service name if service name is not provided.
+    /// </summary>
+        public static readonly string SDefaultServiceName = "unknown_service:" + System.Diagnostics.Process.GetCurrentProcess().ProcessName;
         private static readonly string SDefaultServiceVersion = "{unknown_service_version}";
 
         private string _tracesApiKey;
@@ -130,7 +134,7 @@ namespace Honeycomb.OpenTelemetry
         /// <summary>
         /// Service name used to identify application. Defaults to unknown_process:processname.
         /// </summary>
-        public string ServiceName { get; set; } = SDefaultServiceName;
+        public string ServiceName { get; set; }
 
         /// <summary>
         /// Service version. Defaults to application assembly information version.

--- a/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
+++ b/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
@@ -16,7 +16,7 @@ namespace Honeycomb.OpenTelemetry
     /// </summary>
     public class HoneycombOptions
     {
-        private static readonly string SDefaultServiceName = "unknown_service";
+        private static readonly string SDefaultServiceName = "unknown_service:" + System.Diagnostics.Process.GetCurrentProcess().ProcessName;
         private static readonly string SDefaultServiceVersion = "{unknown_service_version}";
 
         private string _tracesApiKey;
@@ -24,19 +24,6 @@ namespace Honeycomb.OpenTelemetry
         private string _tracesDataset;
         private string _tracesEndpoint;
         private string _metricsEndpoint;
-
-        /// <summary>
-        /// Confirm whether api key is legacy
-        /// </summary>
-        public Boolean isLegacyKey() {
-            // legacy key has 32 characters
-            return _tracesApiKey.Length == 32;
-        }
-
-        static HoneycombOptions()
-        {
-            SDefaultServiceName = SDefaultServiceName + ":" + System.Diagnostics.Process.GetCurrentProcess().ProcessName;
-        }
 
         /// <summary>
         /// Name of the Honeycomb section of IConfiguration
@@ -58,6 +45,15 @@ namespace Honeycomb.OpenTelemetry
         /// <para/>
         /// </summary>
         public string ApiKey { get; set; }
+
+        /// <summary>
+        /// Confirm whether api key is legacy
+        /// </summary>
+        public Boolean isLegacyKey()
+        {
+            // legacy key has 32 characters
+            return ApiKey.Length == 32;
+        }
 
         /// <summary>
         /// API key used to send trace telemetry data to Honeycomb. Defaults to <see cref="ApiKey"/>.

--- a/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
+++ b/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
@@ -20,7 +20,7 @@ namespace Honeycomb.OpenTelemetry
         /// <summary>
         /// Default service name if service name is not provided.
         /// </summary>
-        internal static readonly string SDefaultServiceName = "unknown_service:" + System.Diagnostics.Process.GetCurrentProcess().ProcessName;
+        internal static readonly string SDefaultServiceName = $"unknown_service: {System.Diagnostics.Process.GetCurrentProcess().ProcessName}";
         private static readonly string SDefaultServiceVersion = "{unknown_service_version}";
 
         private string _tracesApiKey;
@@ -53,7 +53,7 @@ namespace Honeycomb.OpenTelemetry
         /// <summary>
         /// Returns whether <see cref="ApiKey"/> is a legacy key.
         /// </summary>
-        internal Boolean IsLegacyKey()
+        internal bool IsLegacyKey()
         {
             // legacy key has 32 characters
             return ApiKey?.Length == 32;

--- a/src/Honeycomb.OpenTelemetry/TracerProviderBuilderExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry/TracerProviderBuilderExtensions.cs
@@ -66,7 +66,7 @@ namespace Honeycomb.OpenTelemetry
 
             if (!string.IsNullOrWhiteSpace(options.TracesApiKey)) {
                 String headers = $"x-honeycomb-team={options.TracesApiKey}";
-                if (options.isLegacyKey()) {
+                if (options.IsLegacyKey()) {
                     // if the key is legacy, add dataset to the header
                     if (!string.IsNullOrWhiteSpace(options.TracesDataset)) {
                         headers += $",x-honeycomb-dataset={options.TracesDataset}";
@@ -84,7 +84,7 @@ namespace Honeycomb.OpenTelemetry
             }
 
             // heads up: even if dataset is set, it will be ignored
-            if (!string.IsNullOrWhiteSpace(options.TracesApiKey) & !options.isLegacyKey() & (!string.IsNullOrWhiteSpace(options.TracesDataset))) {
+            if (!string.IsNullOrWhiteSpace(options.TracesApiKey) & !options.IsLegacyKey() & (!string.IsNullOrWhiteSpace(options.TracesDataset))) {
                 if (!string.IsNullOrWhiteSpace(options.ServiceName)) {
                     Console.WriteLine($"WARN: Dataset is ignored in favor of service name. Data will be sent to service name: {options.ServiceName}");
                 } else {

--- a/src/Honeycomb.OpenTelemetry/TracerProviderBuilderExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry/TracerProviderBuilderExtensions.cs
@@ -49,7 +49,7 @@ namespace Honeycomb.OpenTelemetry
             // if serviceName is null, warn and set to default
             if (string.IsNullOrWhiteSpace(options.ServiceName)) {
                 options.ServiceName = HoneycombOptions.SDefaultServiceName;
-                Console.WriteLine($"WARN: {EnvironmentOptions.getErrorMessage("service name","SERVICE_NAME")}. If left unset, this will show up in Honeycomb as unknown_service:<process_name>.");
+                Console.WriteLine($"WARN: {EnvironmentOptions.GetErrorMessage("service name","SERVICE_NAME")}. If left unset, this will show up in Honeycomb as unknown_service:<process_name>.");
             }
 
             builder
@@ -65,14 +65,14 @@ namespace Honeycomb.OpenTelemetry
                 .AddProcessor(new BaggageSpanProcessor());
 
             if (!string.IsNullOrWhiteSpace(options.TracesApiKey)) {
-                String headers = $"x-honeycomb-team={options.TracesApiKey}";
+                var headers = $"x-honeycomb-team={options.TracesApiKey}";
                 if (options.IsLegacyKey()) {
                     // if the key is legacy, add dataset to the header
                     if (!string.IsNullOrWhiteSpace(options.TracesDataset)) {
                         headers += $",x-honeycomb-dataset={options.TracesDataset}";
                     } else {
                         // if legacy key and missing dataset, warn on missing dataset
-                        Console.WriteLine($"WARN: {EnvironmentOptions.getErrorMessage("dataset", "HONEYCOMB_DATASET")}.");
+                        Console.WriteLine($"WARN: {EnvironmentOptions.GetErrorMessage("dataset", "HONEYCOMB_DATASET")}.");
                     }
                 }
                 builder.AddOtlpExporter(otlpOptions => {
@@ -80,7 +80,7 @@ namespace Honeycomb.OpenTelemetry
                     otlpOptions.Headers = headers;
                 });
             } else {
-                Console.WriteLine($"WARN: {EnvironmentOptions.getErrorMessage("API Key", "HONEYCOMB_API_KEY")}.");
+                Console.WriteLine($"WARN: {EnvironmentOptions.GetErrorMessage("API Key", "HONEYCOMB_API_KEY")}.");
             }
 
             // heads up: even if dataset is set, it will be ignored

--- a/src/Honeycomb.OpenTelemetry/TracerProviderBuilderExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry/TracerProviderBuilderExtensions.cs
@@ -68,7 +68,7 @@ namespace Honeycomb.OpenTelemetry
                 if (options.isLegacyKey()) {
                     // if the key is legacy, add dataset to the header
                     if (!string.IsNullOrWhiteSpace(options.TracesDataset)) {
-                        headers += $",x-honeycomb-team={options.TracesDataset}";
+                        headers += $",x-honeycomb-dataset={options.TracesDataset}";
                     } else {
                         // if legacy key and missing dataset, warn on missing dataset
                         Console.WriteLine("WARN: missing traces dataset");

--- a/src/Honeycomb.OpenTelemetry/TracerProviderBuilderExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry/TracerProviderBuilderExtensions.cs
@@ -49,7 +49,7 @@ namespace Honeycomb.OpenTelemetry
             // if serviceName is null, warn and set to default
             if (string.IsNullOrWhiteSpace(options.ServiceName)) {
                 options.ServiceName = HoneycombOptions.SDefaultServiceName;
-                Console.WriteLine("WARN: missing service name. If left unset, this will show up in Honeycomb as unknown_service:<process_name>.");
+                Console.WriteLine($"WARN: {EnvironmentOptions.getErrorMessage("service name","SERVICE_NAME")}. If left unset, this will show up in Honeycomb as unknown_service:<process_name>.");
             }
 
             builder
@@ -72,7 +72,7 @@ namespace Honeycomb.OpenTelemetry
                         headers += $",x-honeycomb-dataset={options.TracesDataset}";
                     } else {
                         // if legacy key and missing dataset, warn on missing dataset
-                        Console.WriteLine("WARN: missing traces dataset");
+                        Console.WriteLine($"WARN: {EnvironmentOptions.getErrorMessage("dataset", "HONEYCOMB_DATASET")}.");
                     }
                 }
                 builder.AddOtlpExporter(otlpOptions => {
@@ -80,7 +80,7 @@ namespace Honeycomb.OpenTelemetry
                     otlpOptions.Headers = headers;
                 });
             } else {
-                Console.WriteLine("WARN: missing traces API key");
+                Console.WriteLine($"WARN: {EnvironmentOptions.getErrorMessage("API Key", "HONEYCOMB_API_KEY")}.");
             }
 
             if (options.InstrumentHttpClient)

--- a/src/Honeycomb.OpenTelemetry/TracerProviderBuilderExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry/TracerProviderBuilderExtensions.cs
@@ -83,6 +83,16 @@ namespace Honeycomb.OpenTelemetry
                 Console.WriteLine($"WARN: {EnvironmentOptions.getErrorMessage("API Key", "HONEYCOMB_API_KEY")}.");
             }
 
+            // heads up: even if dataset is set, it will be ignored
+            if (!string.IsNullOrWhiteSpace(options.TracesApiKey) & !options.isLegacyKey() & (!string.IsNullOrWhiteSpace(options.TracesDataset))) {
+                if (!string.IsNullOrWhiteSpace(options.ServiceName)) {
+                    Console.WriteLine($"WARN: Dataset is ignored in favor of service name. Data will be sent to service name: {options.ServiceName}");
+                } else {
+                    // should only get here if missing service name and dataset
+                    Console.WriteLine("WARN: Dataset is ignored in favor of service name.");
+                }
+            }      
+
             if (options.InstrumentHttpClient)
             {
 #if NET461

--- a/test/Honeycomb.OpenTelemetry.Tests/EnvironmentOptionsTests.cs
+++ b/test/Honeycomb.OpenTelemetry.Tests/EnvironmentOptionsTests.cs
@@ -11,32 +11,44 @@ namespace Honeycomb.OpenTelemetry
             var values = new Dictionary<string, string>
             {
                 {"HONEYCOMB_API_KEY", "my-api-key"},
+                {"HONEYCOMB_TRACES_API_KEY", "my-traces-api-key"},
+                {"HONEYCOMB_METRICS_API_KEY", "my-metrics-api-key"},
                 {"HONEYCOMB_DATASET", "my-dataset"},
+                {"HONEYCOMB_TRACES_DATASET", "my-traces-dataset"},
+                {"HONEYCOMB_METRICS_DATASET", "my-metrics-dataset"},
                 {"HONEYCOMB_API_ENDPOINT", "my-endpoint"},
+                {"HONEYCOMB_TRACES_ENDPOINT", "my-traces-endpoint"},
+                {"HONEYCOMB_METRICS_ENDPOINT", "my-metrics-endpoint"},
                 {"HONEYCOMB_SAMPLE_RATE", "10"},
                 {"SERVICE_NAME", "my-service-name"},
-                {"SERVICE_VERSION", "my-service-version"},
+                {"SERVICE_VERSION", "my-service-version"}
             };
             var options = new EnvironmentOptions(values);
             Assert.Equal("my-api-key", options.ApiKey);
+            Assert.Equal("my-traces-api-key", options.TracesApiKey);
+            Assert.Equal("my-metrics-api-key", options.MetricsApiKey);
             Assert.Equal("my-dataset", options.Dataset);
+            Assert.Equal("my-traces-dataset", options.TracesDataset);
+            Assert.Equal("my-metrics-dataset", options.MetricsDataset);
             Assert.Equal("my-endpoint", options.ApiEndpoint);
+            Assert.Equal("my-traces-endpoint", options.TracesEndpoint);
+            Assert.Equal("my-metrics-endpoint", options.MetricsEndpoint);
             Assert.Equal((uint) 10, options.SampleRate);
             Assert.Equal("my-service-name", options.ServiceName);
             Assert.Equal("my-service-version", options.ServiceVersion);
         }
 
         [Fact]
-        public void Api_endpoint_returns_default_when_not_set()
+        public void Optional_args_fall_back_to_defaults()
         {
-            var options = new EnvironmentOptions(new Dictionary<string, string>());
+            var options = new EnvironmentOptions(new Dictionary<string, string>());            
+            Assert.Equal(options.ApiKey, options.TracesApiKey);
+            Assert.Equal(options.ApiKey, options.MetricsApiKey);
+            Assert.Equal(options.Dataset, options.TracesDataset);
+            Assert.Empty(options.MetricsDataset);
             Assert.Equal("https://api.honeycomb.io:443", options.ApiEndpoint);
-        }
-
-        [Fact]
-        public void Sample_rate_returns_default_when_not_set()
-        {
-            var options = new EnvironmentOptions(new Dictionary<string, string>());
+            Assert.Equal(options.ApiEndpoint, options.TracesEndpoint);
+            Assert.Equal(options.ApiEndpoint, options.MetricsEndpoint);
             Assert.Equal((uint) 1, options.SampleRate);
         }
 

--- a/test/Honeycomb.OpenTelemetry.Tests/HoneycombOptionsTests.cs
+++ b/test/Honeycomb.OpenTelemetry.Tests/HoneycombOptionsTests.cs
@@ -194,5 +194,18 @@ namespace Honeycomb.OpenTelemetry.Tests
             Assert.Equal("traces", options.TracesEndpoint);
             Assert.Equal("metrics", options.MetricsEndpoint);
         }
+
+        [Fact]
+        public void Legacy_key_length()
+        {
+            var options = new HoneycombOptions { ApiKey = "1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a" };
+            Assert.True(options.isLegacyKey());
+        }
+        [Fact]
+        public void Not_legacy_key_length()
+        {
+            var options = new HoneycombOptions { ApiKey = "specialenvkey" };
+            Assert.False(options.isLegacyKey());
+        }
     }
 }

--- a/test/Honeycomb.OpenTelemetry.Tests/HoneycombOptionsTests.cs
+++ b/test/Honeycomb.OpenTelemetry.Tests/HoneycombOptionsTests.cs
@@ -199,13 +199,13 @@ namespace Honeycomb.OpenTelemetry.Tests
         public void Legacy_key_length()
         {
             var options = new HoneycombOptions { ApiKey = "1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a" };
-            Assert.True(options.isLegacyKey());
+            Assert.True(options.IsLegacyKey());
         }
         [Fact]
         public void Not_legacy_key_length()
         {
             var options = new HoneycombOptions { ApiKey = "specialenvkey" };
-            Assert.False(options.isLegacyKey());
+            Assert.False(options.IsLegacyKey());
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- closes #174 

## Short description of the changes

Details are captured in the issue. Generally, dataset is no longer required but service name is. Warnings have been added to help guide changes that may be needed for missing properties, and the header no longer adds the dataset for tracing telemetry.

Note: no changes to metrics

- adjust default service name to match spec as `unknown_service:<processname>`
- check whether api key is legacy
- set headers and warn depending on api key provided
- add support for metrics with environment variables
- add tests
- add reusable getErrorMessage function

Co-authored-by: Robb Kidd <[robb@thekidds.org](mailto:robb@thekidds.org)>

Logging output when missing all variables:

```shell
WARN: Missing service name. Specify SERVICE_NAME environment variable, or the associated property in appsettings.json or the command line. If left unset, this will show up in Honeycomb as unknown_service:<process_name>.
WARN: Missing API Key. Specify HONEYCOMB_API_KEY environment variable, or the associated property in appsettings.json or the command line.
```

Logging output, using all variables (non-legacy key, service name set to jamie_service):

```shell
WARN: Dataset is ignored in favor of service name. Data will be sent to service name: my-console-app
```

Logging output with only non-legacy api key set:

```shell
WARN: Missing service name. Specify SERVICE_NAME environment variable, or the associated property in appsettings.json or the command line. If left unset, this will show up in Honeycomb as unknown_service:<process_name>.
WARN: Dataset is ignored in favor of service name. Data will be sent to service name: unknown_service:console
```

Logging output with only legacy api key set:

```shell
WARN: Missing service name. Specify SERVICE_NAME environment variable, or the associated property in appsettings.json or the command line. If left unset, this will show up in Honeycomb as unknown_service:<process_name>.
WARN: Missing dataset. Specify HONEYCOMB_DATASET environment variable, or the associated property in appsettings.json or the command line.
```