### PR TITLE
Prepare v0.19.0-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # honeycomb-opentelemetry-dotnet changelog
 
+## [0.19.0-beta] - 2022-02-09
+
+### Enhancements
+
+- Provide more feedback to users to help configure for use in E&S (#175) | [@JamieDanielson](https://github.com/JamieDanielson)
+
+### Fixes
+
+- Validate that HoneycombOptions exists before we do anything (#171) | [@cartermp](https://github.com/cartermp)
+
+### Maintenance
+
+- gh: add re-triage workflow (#166) | [@vreynolds](https://github.com/vreynolds)
+
 ## [0.18.0-beta] - 2021-12-23
 
 ### Fixes

--- a/src/Honeycomb.OpenTelemetry/Honeycomb.OpenTelemetry.csproj
+++ b/src/Honeycomb.OpenTelemetry/Honeycomb.OpenTelemetry.csproj
@@ -11,7 +11,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
 
     <!-- NuGet packaging properties -->
-    <VersionPrefix>0.18.0</VersionPrefix>
+    <VersionPrefix>0.19.0</VersionPrefix>
     <VersionSuffix>beta</VersionSuffix>
     <PackageId>Honeycomb.OpenTelemetry</PackageId>
     <Authors>Honeycomb</Authors>


### PR DESCRIPTION
## Which problem is this PR solving?

- The absence of a 0.19.0-beta in the world.

## Short description of the changes

- Bumped version and updated changelog.

