### PR TITLE
fix: remove space in default service.name

### DIFF
--- a/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
+++ b/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
@@ -20,7 +20,7 @@ namespace Honeycomb.OpenTelemetry
         /// <summary>
         /// Default service name if service name is not provided.
         /// </summary>
-        internal static readonly string SDefaultServiceName = $"unknown_service: {System.Diagnostics.Process.GetCurrentProcess().ProcessName}";
+        internal static readonly string SDefaultServiceName = $"unknown_service:{System.Diagnostics.Process.GetCurrentProcess().ProcessName}";
         private static readonly string SDefaultServiceVersion = "{unknown_service_version}";
 
         private string _tracesApiKey;


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- stock OTEL doesn't add space in the default service.name

<img width="247" alt="image" src="https://user-images.githubusercontent.com/6738917/156673172-5886636b-5f1e-4b1f-93f8-fb8e86f25661.png">


## Short description of the changes

- remove space in our default to match upstream

