### PR TITLE
Capture null options in IServiceColletion.AddHoneycomb

### DIFF
--- a/src/Honeycomb.OpenTelemetry/ServiceCollectionExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry/ServiceCollectionExtensions.cs
@@ -38,6 +38,7 @@ namespace Honeycomb.OpenTelemetry
         public static IServiceCollection AddHoneycomb(this IServiceCollection services, HoneycombOptions options)
         {
 #if (NETSTANDARD2_0_OR_GREATER)
+            options = options ?? new HoneycombOptions();
             services
                 .AddOpenTelemetryTracing(hostingBuilder => hostingBuilder.Configure(((serviceProvider, builder) =>
                     {


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
When running an ASP.NET Core web app and configuring Honeycomb using the `AddHoneycomb` on IServiceCollection, if no configuration options can be found a runtime error is thrown.

Instead, we should capture missing options and inform the user what is missing.

- Closes #130 

## Short description of the changes
- Capture null HoneycombOptions during IServiceCollection.AddHoneycomb and default to empty instance - this ensure a runtime exception is not thrown, and warn messages are shown from TracerProvider.AddHoneycomb for missing / invalid options

Example output:
```
WARN: Missing service name. Specify SERVICE_NAME environment variable, or the associated property in appsettings.json or the command line. If left unset, this will show up in Honeycomb as unknown_service:<process_name>.
WARN: Missing API Key. Specify HONEYCOMB_API_KEY environment variable, or the associated property in appsettings.json or the command line.
```

