### PR TITLE
Add support for providing ResouceBuilder as option

### DIFF
--- a/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
+++ b/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
@@ -2,12 +2,12 @@ using Microsoft.Extensions.Configuration;
 using OpenTelemetry.Instrumentation.Http;
 using OpenTelemetry.Instrumentation.SqlClient;
 using OpenTelemetry.Instrumentation.StackExchangeRedis;
+using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 using StackExchange.Redis;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Metrics;
-using System.Reflection;
 
 namespace Honeycomb.OpenTelemetry
 {
@@ -97,7 +97,7 @@ namespace Honeycomb.OpenTelemetry
         /// Honeycomb dataset to store metrics telemetry data. Defaults to "null".
         /// <para/>
         /// Required to enable metrics.
-        /// </summary>        
+        /// </summary>
         public string MetricsDataset { get; set; }
 
         /// <summary>
@@ -108,7 +108,7 @@ namespace Honeycomb.OpenTelemetry
 
         /// <summary>
         /// API endpoint to send telemetry data. Defaults to <see cref="Endpoint"/>.
-        /// </summary>        
+        /// </summary>
         public string TracesEndpoint
         {
             get { return _tracesEndpoint ?? Endpoint; }
@@ -191,6 +191,15 @@ namespace Honeycomb.OpenTelemetry
         /// <see cref="ServiceName"/> is configured as a meter name by default.
         /// </summary>
         public List<string> MeterNames { get; set; } = new List<string>();
+
+        /// <summary>
+        /// (Optional) Controls whether a new <see cref="ResourceBuilder" /> is configured for use
+        /// with the OpenTelemetry SDK.
+        /// This can be disabled if the calling application wants to set it's own
+        /// <see cref="ResourceBuilder" /> via <see cref="TracerProviderBuilder.SetResourceBuilder(ResourceBuilder)" />.
+        /// Default is true.
+        /// </summary>
+        public bool ConfigureResourceBuilder { get; set; } = true;
 
         private static readonly Dictionary<string, string> CommandLineSwitchMap = new Dictionary<string, string>
         {

--- a/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
+++ b/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
@@ -193,13 +193,11 @@ namespace Honeycomb.OpenTelemetry
         public List<string> MeterNames { get; set; } = new List<string>();
 
         /// <summary>
-        /// (Optional) Controls whether a new <see cref="ResourceBuilder" /> is configured for use
-        /// with the OpenTelemetry SDK.
-        /// This can be disabled if the calling application wants to set it's own
-        /// <see cref="ResourceBuilder" /> via <see cref="TracerProviderBuilder.SetResourceBuilder(ResourceBuilder)" />.
-        /// Default is true.
+        /// The <see cref="ResourceBuilder" /> to use to add Resource attributes to.
+        /// A custom ResouceBuilder can be used to set additional resources and then passed here to add
+        /// Honeycomb attributes.
         /// </summary>
-        public bool ConfigureResourceBuilder { get; set; } = true;
+        public ResourceBuilder ResourceBuilder { get; set; } = ResourceBuilder.CreateDefault();
 
         private static readonly Dictionary<string, string> CommandLineSwitchMap = new Dictionary<string, string>
         {

--- a/src/Honeycomb.OpenTelemetry/TracerProviderBuilderExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry/TracerProviderBuilderExtensions.cs
@@ -55,18 +55,13 @@ namespace Honeycomb.OpenTelemetry
             builder
                 .AddSource(options.ServiceName)
                 .SetSampler(new DeterministicSampler(options.SampleRate))
-                .AddProcessor(new BaggageSpanProcessor());
-
-            if (options.ConfigureResourceBuilder)
-            {
-                builder.SetResourceBuilder(
-                    ResourceBuilder
-                        .CreateDefault()
+                .SetResourceBuilder(
+                    options.ResourceBuilder
                         .AddHoneycombAttributes()
                         .AddEnvironmentVariableDetector()
                         .AddService(serviceName: options.ServiceName, serviceVersion: options.ServiceVersion)
-                );
-            }
+                )
+                .AddProcessor(new BaggageSpanProcessor());
 
             if (!string.IsNullOrWhiteSpace(options.TracesApiKey)) {
                 var headers = $"x-honeycomb-team={options.TracesApiKey}";

--- a/src/Honeycomb.OpenTelemetry/TracerProviderBuilderExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry/TracerProviderBuilderExtensions.cs
@@ -55,14 +55,18 @@ namespace Honeycomb.OpenTelemetry
             builder
                 .AddSource(options.ServiceName)
                 .SetSampler(new DeterministicSampler(options.SampleRate))
-                .SetResourceBuilder(
+                .AddProcessor(new BaggageSpanProcessor());
+
+            if (options.ConfigureResourceBuilder)
+            {
+                builder.SetResourceBuilder(
                     ResourceBuilder
                         .CreateDefault()
                         .AddHoneycombAttributes()
                         .AddEnvironmentVariableDetector()
                         .AddService(serviceName: options.ServiceName, serviceVersion: options.ServiceVersion)
-                )
-                .AddProcessor(new BaggageSpanProcessor());
+                );
+            }
 
             if (!string.IsNullOrWhiteSpace(options.TracesApiKey)) {
                 var headers = $"x-honeycomb-team={options.TracesApiKey}";
@@ -91,7 +95,7 @@ namespace Honeycomb.OpenTelemetry
                     // should only get here if missing service name and dataset
                     Console.WriteLine("WARN: Dataset is ignored in favor of service name.");
                 }
-            }      
+            }
 
             if (options.InstrumentHttpClient)
             {


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Adds `HoneycombOptions.ResourceBuilder` option that can be used by the calling application to set custom attributes. Defaults to `ResouceBuilder.CreateDefault()` to maintain backwards compatability

The reason for this is when an application wants to set it's own attributes. The OpenTelemetry SDK does not allow access to the currently set ResourceBuilder, so we have previously set our own to ensure the correct attributes were set. This change allows users to create their own ResourceBuilder and add custom attributes before handing to `AddHoneycomb` to add.

I went with passing in a configured ResouceBuilder instance over disabling configuring a ResouceBuilder to ensure that all required attributes are set, including env attributes, service name, etc.

- Closes #185

## Short description of the changes
- Adds `ResouceBuilder` property to HoneycombOptions with a default value created from `TracerBuilder.CreateDefault`
- Use the options' ResourceBuilder instead of always setting a new instance
