### PR TITLE
Add OTLP version to headers (HTTP & gRPC)

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,6 +2,7 @@
 
 1. Update changelog
 2. Update VersionPrefix (and VersionSuffix if necessary) in the csproj file
+    - If updating the OTel SDK, update the OTLP version in ``
 3. Open a PR with the above, and merge that into main
 4. Tag the merged commit with the new version (e.g. `v0.10.0-alpha`)
 5. Push the tag upstream (this will kick off the release pipeline in CI)

--- a/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
+++ b/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
@@ -53,10 +53,10 @@ namespace Honeycomb.OpenTelemetry
         /// <summary>
         /// Returns whether <see cref="ApiKey"/> is a legacy key.
         /// </summary>
-        internal bool IsLegacyKey()
+        internal bool IsLegacyKey(string apikey)
         {
             // legacy key has 32 characters
-            return ApiKey?.Length == 32;
+            return apikey?.Length == 32;
         }
 
         /// <summary>

--- a/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
+++ b/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
@@ -51,12 +51,21 @@ namespace Honeycomb.OpenTelemetry
         public string ApiKey { get; set; }
 
         /// <summary>
-        /// Returns whether <see cref="ApiKey"/> is a legacy key.
+        /// Returns whether API key used to send trace telemetry is a legacy key.
         /// </summary>
-        internal bool IsLegacyKey(string apikey)
+        internal bool IsTracesLegacyKey()
         {
             // legacy key has 32 characters
-            return apikey?.Length == 32;
+            return TracesApiKey?.Length == 32;
+        }
+
+        /// <summary>
+        /// Returns whether API key used to send metrics telemetry is a legacy key.
+        /// </summary>
+        internal bool IsMetricsLegacyKey()
+        {
+            // legacy key has 32 characters
+            return MetricsApiKey?.Length == 32;
         }
 
         /// <summary>

--- a/src/Honeycomb.OpenTelemetry/HoneycombOptionsExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry/HoneycombOptionsExtensions.cs
@@ -7,7 +7,7 @@ namespace Honeycomb.OpenTelemetry {
 
         internal static string GetTraceHeaders(this HoneycombOptions options) {
             return GetHeaders(
-                options.IsLegacyKey(),
+                options.IsLegacyKey(options.TracesApiKey),
                 options.TracesApiKey,
                 options.TracesDataset
             );
@@ -15,7 +15,7 @@ namespace Honeycomb.OpenTelemetry {
 
         internal static string GetMetricsHeaders(this HoneycombOptions options) {
             return GetHeaders(
-                options.IsLegacyKey(),
+                options.IsLegacyKey(options.MetricsApiKey),
                 options.MetricsApiKey,
                 options.MetricsDataset
             );

--- a/src/Honeycomb.OpenTelemetry/HoneycombOptionsExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry/HoneycombOptionsExtensions.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+
+namespace Honeycomb.OpenTelemetry {
+    internal static class HoneycombOptionsExtensions {
+        private const string OtlpVersion = "0.16.0";
+
+        internal static string GetTraceHeaders(this HoneycombOptions options) {
+            return GetHeaders(
+                options.IsLegacyKey(),
+                options.TracesApiKey,
+                options.TracesDataset
+            );
+        }
+
+        internal static string GetMetricsHeaders(this HoneycombOptions options) {
+            return GetHeaders(
+                options.IsLegacyKey(),
+                options.MetricsApiKey,
+                options.MetricsDataset
+            );
+        }
+
+        private static string GetHeaders(bool isLegacyKey, string apikey, string dataset) {
+            var headers = new List<string>
+            {
+                $"x-otlp-version={OtlpVersion}",
+                $"x-honeycomb-team={apikey}"
+            };
+            if (isLegacyKey) {
+                // if the key is legacy, add dataset to the header
+                if (!string.IsNullOrWhiteSpace(dataset)) {
+                    headers.Add($"x-honeycomb-dataset={dataset}");
+                } else {
+                    // if legacy key and missing dataset, warn on missing dataset
+                    Console.WriteLine($"WARN: {EnvironmentOptions.GetErrorMessage("dataset", "HONEYCOMB_DATASET")}.");
+                }
+            }
+
+            return string.Join(",", headers);
+        }
+    }
+}

--- a/src/Honeycomb.OpenTelemetry/HoneycombOptionsExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry/HoneycombOptionsExtensions.cs
@@ -7,7 +7,7 @@ namespace Honeycomb.OpenTelemetry {
 
         internal static string GetTraceHeaders(this HoneycombOptions options) {
             return GetHeaders(
-                options.IsLegacyKey(options.TracesApiKey),
+                options.IsTracesLegacyKey(),
                 options.TracesApiKey,
                 options.TracesDataset
             );
@@ -15,7 +15,7 @@ namespace Honeycomb.OpenTelemetry {
 
         internal static string GetMetricsHeaders(this HoneycombOptions options) {
             return GetHeaders(
-                options.IsLegacyKey(options.MetricsApiKey),
+                options.IsMetricsLegacyKey(),
                 options.MetricsApiKey,
                 options.MetricsDataset
             );

--- a/src/Honeycomb.OpenTelemetry/HoneycombOptionsExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry/HoneycombOptionsExtensions.cs
@@ -6,37 +6,30 @@ namespace Honeycomb.OpenTelemetry {
         private const string OtlpVersion = "0.16.0";
 
         internal static string GetTraceHeaders(this HoneycombOptions options) {
-            return GetHeaders(
-                options.IsTracesLegacyKey(),
-                options.TracesApiKey,
-                options.TracesDataset
-            );
-        }
-
-        internal static string GetMetricsHeaders(this HoneycombOptions options) {
-            return GetHeaders(
-                options.IsMetricsLegacyKey(),
-                options.MetricsApiKey,
-                options.MetricsDataset
-            );
-        }
-
-        private static string GetHeaders(bool isLegacyKey, string apikey, string dataset) {
             var headers = new List<string>
             {
                 $"x-otlp-version={OtlpVersion}",
-                $"x-honeycomb-team={apikey}"
+                $"x-honeycomb-team={options.TracesApiKey}"
             };
-            if (isLegacyKey) {
+            if (options.IsTracesLegacyKey()) {
                 // if the key is legacy, add dataset to the header
-                if (!string.IsNullOrWhiteSpace(dataset)) {
-                    headers.Add($"x-honeycomb-dataset={dataset}");
+                if (!string.IsNullOrWhiteSpace(options.TracesDataset)) {
+                    headers.Add($"x-honeycomb-dataset={options.TracesDataset}");
                 } else {
                     // if legacy key and missing dataset, warn on missing dataset
                     Console.WriteLine($"WARN: {EnvironmentOptions.GetErrorMessage("dataset", "HONEYCOMB_DATASET")}.");
                 }
             }
+            return string.Join(",", headers);
+        }
 
+        internal static string GetMetricsHeaders(this HoneycombOptions options) {
+            var headers = new List<string>
+            {
+                $"x-otlp-version={OtlpVersion}",
+                $"x-honeycomb-team={options.MetricsApiKey}",
+                $"x-honeycomb-dataset={options.MetricsDataset}"
+            };
             return string.Join(",", headers);
         }
     }

--- a/src/Honeycomb.OpenTelemetry/MeterProviderBuilderExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry/MeterProviderBuilderExtensions.cs
@@ -49,10 +49,7 @@ namespace Honeycomb.OpenTelemetry
                     .AddOtlpExporter(otlpOptions =>
                     {
                         otlpOptions.Endpoint = new Uri(options.MetricsEndpoint);
-                        if (!string.IsNullOrWhiteSpace(options.MetricsApiKey) &&
-                            !string.IsNullOrWhiteSpace(options.MetricsDataset))
-                            otlpOptions.Headers =
-                                $"x-honeycomb-team={options.MetricsApiKey},x-honeycomb-dataset={options.MetricsDataset}";
+                        otlpOptions.Headers = options.GetMetricsHeaders();
                     });
 
                 builder.AddMeter(options.ServiceName);

--- a/src/Honeycomb.OpenTelemetry/TracerProviderBuilderExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry/TracerProviderBuilderExtensions.cs
@@ -73,7 +73,7 @@ namespace Honeycomb.OpenTelemetry
             }
 
             // heads up: even if dataset is set, it will be ignored
-            if (!string.IsNullOrWhiteSpace(options.TracesApiKey) & !options.IsLegacyKey(options.TracesApiKey) & (!string.IsNullOrWhiteSpace(options.TracesDataset))) {
+            if (!string.IsNullOrWhiteSpace(options.TracesApiKey) & !options.IsTracesLegacyKey() & (!string.IsNullOrWhiteSpace(options.TracesDataset))) {
                 if (!string.IsNullOrWhiteSpace(options.ServiceName)) {
                     Console.WriteLine($"WARN: Dataset is ignored in favor of service name. Data will be sent to service name: {options.ServiceName}");
                 } else {

--- a/src/Honeycomb.OpenTelemetry/TracerProviderBuilderExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry/TracerProviderBuilderExtensions.cs
@@ -73,7 +73,7 @@ namespace Honeycomb.OpenTelemetry
             }
 
             // heads up: even if dataset is set, it will be ignored
-            if (!string.IsNullOrWhiteSpace(options.TracesApiKey) & !options.IsLegacyKey() & (!string.IsNullOrWhiteSpace(options.TracesDataset))) {
+            if (!string.IsNullOrWhiteSpace(options.TracesApiKey) & !options.IsLegacyKey(options.TracesApiKey) & (!string.IsNullOrWhiteSpace(options.TracesDataset))) {
                 if (!string.IsNullOrWhiteSpace(options.ServiceName)) {
                     Console.WriteLine($"WARN: Dataset is ignored in favor of service name. Data will be sent to service name: {options.ServiceName}");
                 } else {

--- a/src/Honeycomb.OpenTelemetry/TracerProviderBuilderExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry/TracerProviderBuilderExtensions.cs
@@ -64,19 +64,9 @@ namespace Honeycomb.OpenTelemetry
                 .AddProcessor(new BaggageSpanProcessor());
 
             if (!string.IsNullOrWhiteSpace(options.TracesApiKey)) {
-                var headers = $"x-honeycomb-team={options.TracesApiKey}";
-                if (options.IsLegacyKey()) {
-                    // if the key is legacy, add dataset to the header
-                    if (!string.IsNullOrWhiteSpace(options.TracesDataset)) {
-                        headers += $",x-honeycomb-dataset={options.TracesDataset}";
-                    } else {
-                        // if legacy key and missing dataset, warn on missing dataset
-                        Console.WriteLine($"WARN: {EnvironmentOptions.GetErrorMessage("dataset", "HONEYCOMB_DATASET")}.");
-                    }
-                }
                 builder.AddOtlpExporter(otlpOptions => {
                     otlpOptions.Endpoint = new Uri(options.TracesEndpoint);
-                    otlpOptions.Headers = headers;
+                    otlpOptions.Headers = options.GetTraceHeaders();
                 });
             } else {
                 Console.WriteLine($"WARN: {EnvironmentOptions.GetErrorMessage("API Key", "HONEYCOMB_API_KEY")}.");

--- a/test/Honeycomb.OpenTelemetry.Tests/HoneycombOptionsExtensionsTests.cs
+++ b/test/Honeycomb.OpenTelemetry.Tests/HoneycombOptionsExtensionsTests.cs
@@ -8,8 +8,8 @@ namespace Honeycomb.OpenTelemetry {
 
         [Theory]
         [InlineData("", "", "x-otlp-version=0.16.0,x-honeycomb-team=")]
-        [InlineData(ModernApiKey, "", "x-otlp-version=0.16.0,x-honeycomb-team=a142c03cf06936628e60f4")]
-        [InlineData(ModernApiKey, "dataset", "x-otlp-version=0.16.0,x-honeycomb-team=a142c03cf06936628e60f4")]
+        [InlineData(ModernApiKey, "", "x-otlp-version=0.16.0,x-honeycomb-team=6936628e60f4c6157fde46")]
+        [InlineData(ModernApiKey, "dataset", "x-otlp-version=0.16.0,x-honeycomb-team=6936628e60f4c6157fde46")]
         [InlineData(ClassicApiKey, "", "x-otlp-version=0.16.0,x-honeycomb-team=a142c03cf06936628e60f4c6157fde46")]
         [InlineData(ClassicApiKey, "dataset", "x-otlp-version=0.16.0,x-honeycomb-team=a142c03cf06936628e60f4c6157fde46,x-honeycomb-dataset=dataset")]
         public void TracesHeaders(string apikey, string dataset, string expectedHeader) {
@@ -23,8 +23,8 @@ namespace Honeycomb.OpenTelemetry {
 
         [Theory]
         [InlineData("", "", "x-otlp-version=0.16.0,x-honeycomb-team=")]
-        [InlineData(ModernApiKey, "", "x-otlp-version=0.16.0,x-honeycomb-team=a142c03cf06936628e60f4")]
-        [InlineData(ModernApiKey, "dataset", "x-otlp-version=0.16.0,x-honeycomb-team=a142c03cf06936628e60f4")]
+        [InlineData(ModernApiKey, "", "x-otlp-version=0.16.0,x-honeycomb-team=6936628e60f4c6157fde46")]
+        [InlineData(ModernApiKey, "dataset", "x-otlp-version=0.16.0,x-honeycomb-team=6936628e60f4c6157fde46")]
         [InlineData(ClassicApiKey, "", "x-otlp-version=0.16.0,x-honeycomb-team=a142c03cf06936628e60f4c6157fde46")]
         [InlineData(ClassicApiKey, "dataset", "x-otlp-version=0.16.0,x-honeycomb-team=a142c03cf06936628e60f4c6157fde46,x-honeycomb-dataset=dataset")]
         public void MetricsHeaders(string apikey, string dataset, string expectedHeader) {

--- a/test/Honeycomb.OpenTelemetry.Tests/HoneycombOptionsExtensionsTests.cs
+++ b/test/Honeycomb.OpenTelemetry.Tests/HoneycombOptionsExtensionsTests.cs
@@ -8,10 +8,10 @@ namespace Honeycomb.OpenTelemetry {
 
         [Theory]
         [InlineData("", "", "x-otlp-version=0.16.0,x-honeycomb-team=")]
-        [InlineData(ModernApiKey, "", "x-otlp-version=0.16.0,x-honeycomb-team=apikey")]
-        [InlineData(ModernApiKey, "dataset", "x-otlp-version=0.16.0,x-honeycomb-team=apikey")]
-        [InlineData(ClassicApiKey, "", "x-otlp-version=0.16.0,x-honeycomb-team=apikey")]
-        [InlineData(ClassicApiKey, "dataset", "x-otlp-version=0.16.0,x-honeycomb-team=apikey,x-honeycomb-dataset=dataset")]
+        [InlineData(ModernApiKey, "", "x-otlp-version=0.16.0,x-honeycomb-team=apikey=a142c03cf06936628e60f4")]
+        [InlineData(ModernApiKey, "dataset", "x-otlp-version=0.16.0,x-honeycomb-team=apikey=a142c03cf06936628e60f4")]
+        [InlineData(ClassicApiKey, "", "x-otlp-version=0.16.0,x-honeycomb-team=apikey=a142c03cf06936628e60f4c6157fde46")]
+        [InlineData(ClassicApiKey, "dataset", "x-otlp-version=0.16.0,x-honeycomb-team=apikey=a142c03cf06936628e60f4c6157fde46,x-honeycomb-dataset=dataset")]
         public void TracesHeaders(string apikey, string dataset, string expectedHeader) {
             var options = new HoneycombOptions
             {

--- a/test/Honeycomb.OpenTelemetry.Tests/HoneycombOptionsExtensionsTests.cs
+++ b/test/Honeycomb.OpenTelemetry.Tests/HoneycombOptionsExtensionsTests.cs
@@ -3,8 +3,8 @@ using Xunit;
 namespace Honeycomb.OpenTelemetry {
     public class HoneycombOptionsExtensionsTests
     {
-        private const string ModernApiKey = "";
-        private const string ClassicApiKey = "";
+        private const string ModernApiKey = "a142c03cf06936628e60f4";
+        private const string ClassicApiKey = "a142c03cf06936628e60f4c6157fde46";
 
         [Theory]
         [InlineData("", "", "x-otlp-version=0.16.0,x-honeycomb-team=")]

--- a/test/Honeycomb.OpenTelemetry.Tests/HoneycombOptionsExtensionsTests.cs
+++ b/test/Honeycomb.OpenTelemetry.Tests/HoneycombOptionsExtensionsTests.cs
@@ -3,8 +3,8 @@ using Xunit;
 namespace Honeycomb.OpenTelemetry {
     public class HoneycombOptionsExtensionsTests
     {
-        private const string ModernApiKey = "a142c03cf06936628e60f4c6157fde46";
-        private const string ClassicApiKey = "6936628e60f4c6157fde46";
+        private const string ModernApiKey = "6936628e60f4c6157fde46";
+        private const string ClassicApiKey = "a142c03cf06936628e60f4c6157fde46";
 
         [Theory]
         [InlineData("", "", "x-otlp-version=0.16.0,x-honeycomb-team=")]

--- a/test/Honeycomb.OpenTelemetry.Tests/HoneycombOptionsExtensionsTests.cs
+++ b/test/Honeycomb.OpenTelemetry.Tests/HoneycombOptionsExtensionsTests.cs
@@ -22,7 +22,7 @@ namespace Honeycomb.OpenTelemetry {
         }
 
         [Theory]
-        [InlineData("", "", "x-otlp-version=0.16.0,x-honeycomb-team=")]
+        [InlineData("", "", "x-otlp-version=0.16.0,x-honeycomb-team=,x-honeycomb-dataset=")]
         [InlineData(ModernApiKey, "", "x-otlp-version=0.16.0,x-honeycomb-team=6936628e60f4c6157fde46,x-honeycomb-dataset=")]
         [InlineData(ModernApiKey, "dataset", "x-otlp-version=0.16.0,x-honeycomb-team=6936628e60f4c6157fde46,x-honeycomb-dataset=dataset")]
         [InlineData(ClassicApiKey, "", "x-otlp-version=0.16.0,x-honeycomb-team=a142c03cf06936628e60f4c6157fde46,x-honeycomb-dataset=")]

--- a/test/Honeycomb.OpenTelemetry.Tests/HoneycombOptionsExtensionsTests.cs
+++ b/test/Honeycomb.OpenTelemetry.Tests/HoneycombOptionsExtensionsTests.cs
@@ -1,0 +1,36 @@
+using Xunit;
+
+namespace Honeycomb.OpenTelemetry {
+    public class HoneycombOptionsExtensionsTests
+    {
+        private const string ModernApiKey = "";
+        private const string ClassicApiKey = "";
+
+        [Theory]
+        [InlineData("", "", "x-otlp-version=0.16.0,x-honeycomb-team=")]
+        [InlineData(ModernApiKey, "", "x-otlp-version=0.16.0,x-honeycomb-team=apikey")]
+        [InlineData(ModernApiKey, "dataset", "x-otlp-version=0.16.0,x-honeycomb-team=apikey")]
+        [InlineData(ClassicApiKey, "", "x-otlp-version=0.16.0,x-honeycomb-team=apikey")]
+        [InlineData(ClassicApiKey, "dataset", "x-otlp-version=0.16.0,x-honeycomb-team=apikey,x-honeycomb-dataset=dataset")]
+        public void TracesHeaders(string apikey, string dataset, string expectedHeader) {
+            var options = new HoneycombOptions
+            {
+                TracesApiKey = apikey,
+                TracesDataset = dataset
+            };
+            Assert.Equal(expectedHeader, options.GetTraceHeaders());
+        }
+
+        [Theory]
+        [InlineData(ModernApiKey, "", "x-otlp-version=0.16.0,x-honeycomb-team=apikey")]
+        [InlineData(ClassicApiKey, "dataset", "x-otlp-version=0.16.0,x-honeycomb-team=apikey,x-honeycomb-dataset=dataset")]
+        public void MetricsHeaders(string apikey, string dataset, string expectedHeader) {
+            var options = new HoneycombOptions
+            {
+                MetricsApiKey = apikey,
+                MetricsDataset = dataset
+            };
+            Assert.Equal(expectedHeader, options.GetMetricsHeaders());
+        }
+    }
+}

--- a/test/Honeycomb.OpenTelemetry.Tests/HoneycombOptionsExtensionsTests.cs
+++ b/test/Honeycomb.OpenTelemetry.Tests/HoneycombOptionsExtensionsTests.cs
@@ -8,10 +8,10 @@ namespace Honeycomb.OpenTelemetry {
 
         [Theory]
         [InlineData("", "", "x-otlp-version=0.16.0,x-honeycomb-team=")]
-        [InlineData(ModernApiKey, "", "x-otlp-version=0.16.0,x-honeycomb-team=apikey=a142c03cf06936628e60f4")]
-        [InlineData(ModernApiKey, "dataset", "x-otlp-version=0.16.0,x-honeycomb-team=apikey=a142c03cf06936628e60f4")]
-        [InlineData(ClassicApiKey, "", "x-otlp-version=0.16.0,x-honeycomb-team=apikey=a142c03cf06936628e60f4c6157fde46")]
-        [InlineData(ClassicApiKey, "dataset", "x-otlp-version=0.16.0,x-honeycomb-team=apikey=a142c03cf06936628e60f4c6157fde46,x-honeycomb-dataset=dataset")]
+        [InlineData(ModernApiKey, "", "x-otlp-version=0.16.0,x-honeycomb-team=a142c03cf06936628e60f4")]
+        [InlineData(ModernApiKey, "dataset", "x-otlp-version=0.16.0,x-honeycomb-team=a142c03cf06936628e60f4")]
+        [InlineData(ClassicApiKey, "", "x-otlp-version=0.16.0,x-honeycomb-team=a142c03cf06936628e60f4c6157fde46")]
+        [InlineData(ClassicApiKey, "dataset", "x-otlp-version=0.16.0,x-honeycomb-team=a142c03cf06936628e60f4c6157fde46,x-honeycomb-dataset=dataset")]
         public void TracesHeaders(string apikey, string dataset, string expectedHeader) {
             var options = new HoneycombOptions
             {
@@ -22,8 +22,11 @@ namespace Honeycomb.OpenTelemetry {
         }
 
         [Theory]
-        [InlineData(ModernApiKey, "", "x-otlp-version=0.16.0,x-honeycomb-team=apikey")]
-        [InlineData(ClassicApiKey, "dataset", "x-otlp-version=0.16.0,x-honeycomb-team=apikey,x-honeycomb-dataset=dataset")]
+        [InlineData("", "", "x-otlp-version=0.16.0,x-honeycomb-team=")]
+        [InlineData(ModernApiKey, "", "x-otlp-version=0.16.0,x-honeycomb-team=a142c03cf06936628e60f4")]
+        [InlineData(ModernApiKey, "dataset", "x-otlp-version=0.16.0,x-honeycomb-team=a142c03cf06936628e60f4")]
+        [InlineData(ClassicApiKey, "", "x-otlp-version=0.16.0,x-honeycomb-team=a142c03cf06936628e60f4c6157fde46")]
+        [InlineData(ClassicApiKey, "dataset", "x-otlp-version=0.16.0,x-honeycomb-team=a142c03cf06936628e60f4c6157fde46,x-honeycomb-dataset=dataset")]
         public void MetricsHeaders(string apikey, string dataset, string expectedHeader) {
             var options = new HoneycombOptions
             {

--- a/test/Honeycomb.OpenTelemetry.Tests/HoneycombOptionsExtensionsTests.cs
+++ b/test/Honeycomb.OpenTelemetry.Tests/HoneycombOptionsExtensionsTests.cs
@@ -23,9 +23,9 @@ namespace Honeycomb.OpenTelemetry {
 
         [Theory]
         [InlineData("", "", "x-otlp-version=0.16.0,x-honeycomb-team=")]
-        [InlineData(ModernApiKey, "", "x-otlp-version=0.16.0,x-honeycomb-team=6936628e60f4c6157fde46")]
-        [InlineData(ModernApiKey, "dataset", "x-otlp-version=0.16.0,x-honeycomb-team=6936628e60f4c6157fde46")]
-        [InlineData(ClassicApiKey, "", "x-otlp-version=0.16.0,x-honeycomb-team=a142c03cf06936628e60f4c6157fde46")]
+        [InlineData(ModernApiKey, "", "x-otlp-version=0.16.0,x-honeycomb-team=6936628e60f4c6157fde46,x-honeycomb-dataset=")]
+        [InlineData(ModernApiKey, "dataset", "x-otlp-version=0.16.0,x-honeycomb-team=6936628e60f4c6157fde46,x-honeycomb-dataset=dataset")]
+        [InlineData(ClassicApiKey, "", "x-otlp-version=0.16.0,x-honeycomb-team=a142c03cf06936628e60f4c6157fde46,x-honeycomb-dataset=")]
         [InlineData(ClassicApiKey, "dataset", "x-otlp-version=0.16.0,x-honeycomb-team=a142c03cf06936628e60f4c6157fde46,x-honeycomb-dataset=dataset")]
         public void MetricsHeaders(string apikey, string dataset, string expectedHeader) {
             var options = new HoneycombOptions

--- a/test/Honeycomb.OpenTelemetry.Tests/HoneycombOptionsExtensionsTests.cs
+++ b/test/Honeycomb.OpenTelemetry.Tests/HoneycombOptionsExtensionsTests.cs
@@ -3,8 +3,8 @@ using Xunit;
 namespace Honeycomb.OpenTelemetry {
     public class HoneycombOptionsExtensionsTests
     {
-        private const string ModernApiKey = "a142c03cf06936628e60f4";
-        private const string ClassicApiKey = "a142c03cf06936628e60f4c6157fde46";
+        private const string ModernApiKey = "a142c03cf06936628e60f4c6157fde46";
+        private const string ClassicApiKey = "6936628e60f4c6157fde46";
 
         [Theory]
         [InlineData("", "", "x-otlp-version=0.16.0,x-honeycomb-team=")]

--- a/test/Honeycomb.OpenTelemetry.Tests/HoneycombOptionsTests.cs
+++ b/test/Honeycomb.OpenTelemetry.Tests/HoneycombOptionsTests.cs
@@ -198,14 +198,14 @@ namespace Honeycomb.OpenTelemetry.Tests
         [Fact]
         public void Legacy_key_length()
         {
-            var options = new HoneycombOptions { ApiKey = "1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a" };
-            Assert.True(options.IsLegacyKey());
+            var options = new HoneycombOptions();
+            Assert.True(options.IsLegacyKey("1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a"));
         }
         [Fact]
         public void Not_legacy_key_length()
         {
-            var options = new HoneycombOptions { ApiKey = "specialenvkey" };
-            Assert.False(options.IsLegacyKey());
+            var options = new HoneycombOptions();
+            Assert.False(options.IsLegacyKey("specialenvkey"));
         }
     }
 }

--- a/test/Honeycomb.OpenTelemetry.Tests/HoneycombOptionsTests.cs
+++ b/test/Honeycomb.OpenTelemetry.Tests/HoneycombOptionsTests.cs
@@ -198,14 +198,16 @@ namespace Honeycomb.OpenTelemetry.Tests
         [Fact]
         public void Legacy_key_length()
         {
-            var options = new HoneycombOptions();
-            Assert.True(options.IsLegacyKey("1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a"));
+            var options = new HoneycombOptions { ApiKey = "1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a" };
+            Assert.True(options.IsTracesLegacyKey());
+            Assert.True(options.IsMetricsLegacyKey());
         }
         [Fact]
         public void Not_legacy_key_length()
         {
-            var options = new HoneycombOptions();
-            Assert.False(options.IsLegacyKey("specialenvkey"));
+            var options = new HoneycombOptions { ApiKey = "specialenvkey" };
+            Assert.False(options.IsTracesLegacyKey());
+            Assert.False(options.IsMetricsLegacyKey());
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Adds the `x-otlp-version` header that indicates what version of OTLP the distro is using. This is useful for understanding what proto versions users are sending to us.

- Implements https://github.com/honeycombio/specs/pull/5

## Short description of the changes
- Refactors the creation of headers into a new HoneycombOptionsExtensions class
- Update Trace and Metric exporters to use new helper func
- Add `x-otlp-version` header when creating headers
- Add unit tests

NOTE: This is currently not passing tests, the failing tests are:
- https://github.com/honeycombio/honeycomb-opentelemetry-dotnet/pull/205/files#diff-b555e6b4319cd01a92eabf9fa3b8fc3f46a43f9c220cf3a457645bdb21190f18R14
- https://github.com/honeycombio/honeycomb-opentelemetry-dotnet/pull/205/files#diff-b555e6b4319cd01a92eabf9fa3b8fc3f46a43f9c220cf3a457645bdb21190f18R29