### PR TITLE
Update README to point to docs website for setup instructions

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,11 @@
+## Building & Testing
+
+### Using local packages with other projects
+
+To share this project with another local project you will need to build and store the distributable nuget package in a local nuget source directory. The following makefile target creates a local nuget source, builds and publishes the packages.
+
+`make publish_local`
+
+After the command has run, you can add the package to another project using the normal add package command:
+
+`dotnet add package Honeycomb.OpenTelemetry`

--- a/README.md
+++ b/README.md
@@ -6,8 +6,12 @@
 This is Honeycomb's distribution of OpenTelemetry for .NET.
 It makes getting started with OpenTelemetry and Honeycomb easier!
 
-**NOTE** This project took over a pre-existing Nuget package `Honeycomb.OpenTelemetry` after version `0.9.0-pre`. 
-Version `0.9.0-pre` is the only version that will contain the initial implementation [Honeycomb exporter](https://github.com/honeycombio/opentelemetry-dotnet).
+## Getting Started
+
+Honeycomb's OpenTelemetry .NET SDK gives you the ability to add manual instrumentation to your applications.
+
+- [Documentation](https://docs.honeycomb.io/getting-data-in/dotnet/opentelemetry-distro/)
+- [Examples](/examples/)
 
 ## Why would I want to use this?
 
@@ -16,76 +20,6 @@ Version `0.9.0-pre` is the only version that will contain the initial implementa
 - Deterministic sampling!
 - Multi-span attributes!
 
-## Getting Started
+## License
 
-### Installing the Honeycomb.OpenTelemetry package
-
-You can add the package to your application by using the following command:
-
-`dotnet add package Honeycomb.OpenTelemetry --prerelease`
-
-### Configuration
-
-The two ways to configure the Honeycomb OpenTelemetry SDK distro to send data to Honeycomb are via command line arguments and `IConfiguration` instances (eg via appsettings.json).
-
-The available configuration options are:
-
-|Command line argument|Appsetting key|Description|
-|-|-|-|
-|`--honeycomb-apikey`|Honeycomb.ApiKey|`required` The API key used to send data|
-|`--honeycomb-dataset`|Honeycomb.Dataset|`required` The dataset to store telemetry data in|
-|`--honeycomb-samplerate`|Honeycomb.SampleRate|`optional` Defaults to 1 (sample everything)|
-|`--honeycomb-endpoint`|Honeycomb.Endpoint|`optional` Override the endpoint data is sent to|
-|`--service-name`|Honeycomb.ServiceName|`optional` Defaults to project's assembly name|
-|`--service-version`|Honeycomb.ServieVersion|`optional` Defaults to project's assembly version|
-
-*NOTE* While ServiceName is optional, it can be useful to set it to something that best describes the process that is being traced. eg `auth-service`
-
-Using command line arguments:
-```bash
-dotnet run --service-name=my-app --honeycomb-apikey={apikey} --honeycomb-dataset={dataset}
-```
-
-Using appsettings.json:
-```json
-{
-  "Honeycomb": {
-    "ServiceName": "my-app",
-    "ApiKey": "{apikey}",
-    "Dataset": "{dataset}"
-  }
-}
-```
-
-### Examples
-
-See the [examples](examples) directory for some sample applications showing how to configure the library.    
-
-
-## Building & Testing
-
-### Prerequisites to Build
-
-You will need to download and install the latest .NET SDK:
-
-- [.NET 5.0](https://dotnet.microsoft.com/download/dotnet/5.0)
-
-The following makefile commands build the projects:
-
-`make` or `make build`
-
-The following makefile command executes tests:
-
-`make test`
-
-### Using local packages with other projects
-
-To share this project with another local project you will need to build and store the distributable nuget package in a local nuget source directory. The following makefile target creates a local nuget source, builds and publishes the packages.
-
-`make publish_local`
-
-After the command has run, you can add the package to another project using the normal add package command:
-
-`dotnet add package Honeycomb.OpenTelemetry`
-
-The default location is `${HOME}/.nuget/local` and can overridden to another location by setting the `NUGET_PACKAGES_LOCAL` environment variable.
+[Apache 2.0 License](./LICENSE).


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Updates README to direct readers to Honeycomb docs for instructions on how to setup and use the distro. This helps ensure we have a single place to update documentation.

- Closes #206   

## Short description of the changes
- Update README to point to docs website instead of having local instructions