### PR TITLE
Update minimum target framework from net461 to net462

### DIFF
--- a/src/Honeycomb.OpenTelemetry/Honeycomb.OpenTelemetry.csproj
+++ b/src/Honeycomb.OpenTelemetry/Honeycomb.OpenTelemetry.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
     <!-- For SourceLink. See: https://github.com/dotnet/sourcelink#using-source-link-in-net-projects -->
@@ -39,7 +39,7 @@
   </ItemGroup>
 
   <Choose>
-    <When Condition=" '$(TargetFramework)' == 'net461' ">
+    <When Condition=" '$(TargetFramework)' == 'net462' ">
       <ItemGroup>
         <PackageReference Include="Microsoft.AspNet.WebApi" Version="5.2.7" />
         <PackageReference Include="OpenTelemetry.Instrumentation.AspNet" Version="1.0.0-rc9.1" />

--- a/src/Honeycomb.OpenTelemetry/TracerProviderBuilderExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry/TracerProviderBuilderExtensions.cs
@@ -3,7 +3,7 @@ using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 using System;
 
-#if NET461
+#if NET462
 using System.Collections.Generic;
 #endif
 
@@ -88,7 +88,7 @@ namespace Honeycomb.OpenTelemetry
 
             if (options.InstrumentHttpClient)
             {
-#if NET461
+#if NET462
                     builder.AddHttpClientInstrumentation();
 #else
                 builder.AddHttpClientInstrumentation(options.ConfigureHttpClientInstrumentationOptions);
@@ -106,7 +106,7 @@ namespace Honeycomb.OpenTelemetry
                     options.ConfigureStackExchangeRedisClientInstrumentationOptions);
             }
 
-#if NET461
+#if NET462
             builder.AddAspNetInstrumentation(opts =>
                 opts.Enrich = (activity, eventName, _) =>
                 {


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- [net461 has reached end of life in April 2022](https://devblogs.microsoft.com/dotnet/net-framework-4-5-2-4-6-4-6-1-will-reach-end-of-support-on-april-26-2022/)
- upstream instrumentation updated their target version to net462, so we need to follow suit in order to upgrade

## Short description of the changes

- replace net461 with net462

