### PR TITLE
Inject an activitysource

### DIFF
--- a/src/Honeycomb.OpenTelemetry/ServiceCollectionExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry/ServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using OpenTelemetry;
 using OpenTelemetry.Trace;
 using StackExchange.Redis;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace Honeycomb.OpenTelemetry
 {
@@ -64,6 +65,7 @@ namespace Honeycomb.OpenTelemetry
                     }))
                 )
                 .AddSingleton(TracerProvider.Default.GetTracer(options.ServiceName))
+                .AddSingleton(new ActivitySource(options.ServiceName))
                 .AddOpenTelemetryMetrics(builder => builder.AddHoneycomb(options));
 #endif
             return services;


### PR DESCRIPTION
Fixes https://github.com/honeycombio/honeycomb-opentelemetry-dotnet/issues/212

So. I don't like the fact that .NET uses system diagnostics by default rather than the _actual_ OTel API nouns and verbs. I also really don't like dependency injection and believe that developers should just create singleton instances of these things.

But.

A lot of .NET developers like using dependency injection, and in some cases, they must use it (as it _can_ be the best solution to their problem). And a lot of .NET developers _want_ to use the system diagnostics APIs.

So, this enables them to do it with DI, which should allow them to do things like define a controller or API route that "magically" has an `ActivitySource` named after their service available to them. For example, our sample can use it like this:

```csharp
public WeatherForecastController(ILogger<WeatherForecastController> logger, ActivitySource source, Meter meter)
{
    _logger = logger;
    _source_ = source;
    _counter = meter.CreateCounter<int>("sheep");
}

//...

public async Task<IEnumerable<WeatherForecast>> Get()
{
    using (var activity = _source_.StartActivity("sleep"))
    {
        activity?.SetTag("delay_ms", 100);
        await Task.Delay(TimeSpan.FromMilliseconds(100));
    }

    _counter.Add(1);
    
    var rng = new Random();
    return Enumerable.Range(1, 5).Select(index => new WeatherForecast
    {
        Date = DateTime.Now.AddDays(index),
        TemperatureC = rng.Next(-20, 55),
        Summary = Summaries[rng.Next(Summaries.Length)]
    })
    .ToArray();
}
```

In other words, this meets more developers where they are, even if that place is not entirely aligned with my own idealogical beliefs 🙂.

I can also add a new sample to the repo that shows how to use this rather than the tracer. And I can also update docs.