### PR TITLE
Add support for `OTEL_SERVICE_NAME` environment variable

### DIFF
--- a/examples/aspnetcore/appsettings.json
+++ b/examples/aspnetcore/appsettings.json
@@ -8,9 +8,7 @@
   },
   "AllowedHosts": "*",
   "Honeycomb": {
-    "ServiceName": "my-web-app",
-    "ApiKey": "{apikey}",
-    "TracesDataset": "{traces-dataset}",
-    "MetricsDataset": "{metrics-dataset}"
+    "ServiceName": "",
+    "ApiKey": ""
   }
 }

--- a/examples/aspnetcore/appsettings.json
+++ b/examples/aspnetcore/appsettings.json
@@ -8,7 +8,9 @@
   },
   "AllowedHosts": "*",
   "Honeycomb": {
-    "ServiceName": "",
-    "ApiKey": ""
+    "ServiceName": "my-web-app",
+    "ApiKey": "{apikey}",
+    "TracesDataset": "{traces-dataset}",
+    "MetricsDataset": "{metrics-dataset}"
   }
 }

--- a/src/Honeycomb.OpenTelemetry/EnvironmentOptions.cs
+++ b/src/Honeycomb.OpenTelemetry/EnvironmentOptions.cs
@@ -43,7 +43,7 @@ namespace Honeycomb.OpenTelemetry
         private string GetEnvironmentVariable(string key, string defaultValue = "")
         {
             var value = _environmentService[key];
-            if (value as string != null)
+            if (value is string str && !string.IsNullOrWhiteSpace(str))
             {
                 return (string)value;
             }

--- a/src/Honeycomb.OpenTelemetry/EnvironmentOptions.cs
+++ b/src/Honeycomb.OpenTelemetry/EnvironmentOptions.cs
@@ -14,7 +14,7 @@ namespace Honeycomb.OpenTelemetry
         private const string TracesEndpointKey = "HONEYCOMB_TRACES_ENDPOINT";
         private const string MetricsEndpointKey = "HONEYCOMB_METRICS_ENDPOINT";
         private const string SampleRateKey = "HONEYCOMB_SAMPLE_RATE";
-        private const string ServiceNameKey = "SERVICE_NAME";
+        private const string ServiceNameKey = "OTEL_SERVICE_NAME";
         private const string ServiceVersionKey = "SERVICE_VERSION";
         private const string EnableLocalVisualizationsKey = "ENABLE_LOCAL_VISUALIZATIONS";
         private const uint DefaultSampleRate = 1;
@@ -43,9 +43,9 @@ namespace Honeycomb.OpenTelemetry
         private string GetEnvironmentVariable(string key, string defaultValue = "")
         {
             var value = _environmentService[key];
-            if (value is string && !string.IsNullOrWhiteSpace((string) value))
+            if (value is string && !string.IsNullOrWhiteSpace((string)value))
             {
-                return (string) value;
+                return (string)value;
             }
 
             return defaultValue;

--- a/src/Honeycomb.OpenTelemetry/EnvironmentOptions.cs
+++ b/src/Honeycomb.OpenTelemetry/EnvironmentOptions.cs
@@ -43,7 +43,7 @@ namespace Honeycomb.OpenTelemetry
         private string GetEnvironmentVariable(string key, string defaultValue = "")
         {
             var value = _environmentService[key];
-            if (value is string && !string.IsNullOrWhiteSpace((string)value))
+            if (value as string != null)
             {
                 return (string)value;
             }

--- a/src/Honeycomb.OpenTelemetry/TracerProviderBuilderExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry/TracerProviderBuilderExtensions.cs
@@ -75,8 +75,6 @@ namespace Honeycomb.OpenTelemetry
                 )
                 .AddProcessor(new BaggageSpanProcessor());
 
-            Console.WriteLine(options.ServiceName);
-
             if (!string.IsNullOrWhiteSpace(options.TracesApiKey))
             {
                 builder.AddOtlpExporter(otlpOptions =>

--- a/src/Honeycomb.OpenTelemetry/TracerProviderBuilderExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry/TracerProviderBuilderExtensions.cs
@@ -46,8 +46,8 @@ namespace Honeycomb.OpenTelemetry
                 throw new ArgumentNullException(nameof(options), "No Honeycomb options have been set in appsettings.json, environment variables, or the command line.");
             }
 
+            // TODO: Add support for other environment variables
             var environmentOptions = new EnvironmentOptions(Environment.GetEnvironmentVariables());
-            // TODO: merge options and environment options
 
             // if service name set in environment, prioritize it    
             if (!string.IsNullOrWhiteSpace(environmentOptions.ServiceName))

--- a/test/Honeycomb.OpenTelemetry.Tests/EnvironmentOptionsTests.cs
+++ b/test/Honeycomb.OpenTelemetry.Tests/EnvironmentOptionsTests.cs
@@ -20,7 +20,7 @@ namespace Honeycomb.OpenTelemetry
                 {"HONEYCOMB_TRACES_ENDPOINT", "my-traces-endpoint"},
                 {"HONEYCOMB_METRICS_ENDPOINT", "my-metrics-endpoint"},
                 {"HONEYCOMB_SAMPLE_RATE", "10"},
-                {"SERVICE_NAME", "my-service-name"},
+                {"OTEL_SERVICE_NAME", "my-service-name"},
                 {"SERVICE_VERSION", "my-service-version"},
                 {"ENABLE_LOCAL_VISUALIZATIONS", "true" }
             };
@@ -34,7 +34,7 @@ namespace Honeycomb.OpenTelemetry
             Assert.Equal("my-endpoint", options.ApiEndpoint);
             Assert.Equal("my-traces-endpoint", options.TracesEndpoint);
             Assert.Equal("my-metrics-endpoint", options.MetricsEndpoint);
-            Assert.Equal((uint) 10, options.SampleRate);
+            Assert.Equal((uint)10, options.SampleRate);
             Assert.Equal("my-service-name", options.ServiceName);
             Assert.Equal("my-service-version", options.ServiceVersion);
             Assert.True(options.EnableLocalVisualizations);
@@ -43,7 +43,7 @@ namespace Honeycomb.OpenTelemetry
         [Fact]
         public void Optional_args_fall_back_to_defaults()
         {
-            var options = new EnvironmentOptions(new Dictionary<string, string>());            
+            var options = new EnvironmentOptions(new Dictionary<string, string>());
             Assert.Equal(options.ApiKey, options.TracesApiKey);
             Assert.Equal(options.ApiKey, options.MetricsApiKey);
             Assert.Equal(options.Dataset, options.TracesDataset);
@@ -51,7 +51,7 @@ namespace Honeycomb.OpenTelemetry
             Assert.Equal("https://api.honeycomb.io:443", options.ApiEndpoint);
             Assert.Equal(options.ApiEndpoint, options.TracesEndpoint);
             Assert.Equal(options.ApiEndpoint, options.MetricsEndpoint);
-            Assert.Equal((uint) 1, options.SampleRate);
+            Assert.Equal((uint)1, options.SampleRate);
             Assert.False(options.EnableLocalVisualizations);
         }
 
@@ -63,7 +63,7 @@ namespace Honeycomb.OpenTelemetry
                 {"HONEYCOMB_SAMPLE_RATE", "invalid"}
             };
             var options = new EnvironmentOptions(values);
-            Assert.Equal((uint) 1, options.SampleRate);
+            Assert.Equal((uint)1, options.SampleRate);
         }
     }
 }


### PR DESCRIPTION
## Which problem is this PR solving?
Resolves the bug where the `OTEL_SERVICE_NAME` environment variable is set but does not get used and defaults to `unknown_service:process_name`.

- Closes #207 

## Short description of the changes
- Change `SERVICE_NAME` to `OTEL_SERVICE_NAME` (this is a breaking change, but it never worked in the first place so is it really? 🤔 )
- Read environment variables in `TracerProviderBuilderExtensions` and add support for using `OTEL_SERVICE_NAME` env var
- Move `AddEnvironmentVariableDetector` to be the last in the chain so that nothing can override upstream OTel env variables

## Questions
- What is the priority order of all the different ways to set `service.name`?
  - `OTEL_SERVICE_NAME` env var
  - `HONEYCOMB__SERVICE_NAME` env var (related to appsettings.json)
  - `ServiceName` in appsettings.json
  - Default service name
- Why do we need to explicitly check for the `OTEL_SERVICE_NAME` env var if we're using `AddEnvironmentVariableDetector`?
  - The upstream env var detector works well except that we need to set the service name when we call `AddSource`, if we don't explicitly override `options.ServiceName` and `OTEL_SERVICE_NAME` env var is being used, the source name will be `unknown_service:proccess_name` and `service.name` will be whatever is set in the env var causing them to be different. 
- What about the other environment variables?
  - They are currently unsupported because we were never actually invoking the `EnvironmentOptions` class anywhere, we should add support for them and think about a good system to override `HoneycombOptions` so that we don't have to change things in too many places
- Why are there no tests added?!
  -  We don't have tests for `TracerProviderBuilderExtensions` because it seems difficult to unit test, we're currently working on smoke tests and we should definitely add env variable testing there!

## Testing
- [x] `OTEL_SERVICE_NAME` env var sets `service.name` and is the highest priority 
- [x] `HONEYCOMB__SERVICE_NAME` env var can set `service.name`
- [x] `ServiceName` in appsettings.json can set `service.name`
- [x] If the service name isn't set anywhere it defaults to `unknown_service:process_name`
- [x] We never run into the case where `AddSource` has an empty `name` because this causes errors and no telemetry to get through

[Honeycomb query](https://ui.honeycomb.io/honeycomb-telemetry-testing/environments/purvi?query=%7B%22time_range%22%3A600%2C%22granularity%22%3A0%2C%22breakdowns%22%3A%5B%22service.name%22%2C%22service_name.source%22%5D%2C%22calculations%22%3A%5B%7B%22op%22%3A%22COUNT%22%7D%5D%2C%22orders%22%3A%5B%7B%22op%22%3A%22COUNT%22%2C%22order%22%3A%22descending%22%7D%5D%2C%22havings%22%3A%5B%5D%2C%22limit%22%3A1000%7D) testing the cases listed above.


  

