### PR TITLE
Specify OTel version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,13 @@
 
 [![OSS Lifecycle](https://img.shields.io/osslifecycle/honeycombio/honeycomb-opentelemetry-dotnet)](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md)
 [![CircleCI](https://circleci.com/gh/honeycombio/honeycomb-opentelemetry-dotnet.svg?style=shield)](https://circleci.com/gh/honeycombio/honeycomb-opentelemetry-dotnet)
+[![Dependencies](https://img.shields.io/librariesio/release/nuget/Honeycomb.Opentelemetry.svg)](https://github.com/honeycombio/honeycomb-opentelemetry-dotnet/blob/main/src/Honeycomb.OpenTelemetry/Honeycomb.OpenTelemetry.csproj)
+[![Nuget](https://img.shields.io/nuget/v/Honeycomb.OpenTelemetry.svg)](https://www.nuget.org/packages/Honeycomb.OpenTelemetry)
 
 This is Honeycomb's distribution of OpenTelemetry for .NET.
 It makes getting started with OpenTelemetry and Honeycomb easier!
+
+**OpenTelemetry Version: 1.3.0**
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@
 This is Honeycomb's distribution of OpenTelemetry for .NET.
 It makes getting started with OpenTelemetry and Honeycomb easier!
 
-**OpenTelemetry Version: 1.3.0**
+Latest release built with:
+
+- [OpenTelemetry Version 1.3.0](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.3.0)
 
 ## Getting Started
 


### PR DESCRIPTION
## Which problem is this PR solving?
Specifies the OTel version the distro is using in the README
- Closes #93 

## Short description of the changes
- Adds a badge indicating whether dependencies are up to date
- Adds a nuget version badge for the Honeycomb.OpenTelemetry package
- Adds a line in the README that indicates what version of OTel is being used

## Context
There wasn't a great automated way I could find to indicate the version of OTel that this distro is using. Nuget package version badges only show the latest version and there doesn't seem to be support for looking inside a .csproj file to figure out what dependent version is being used. So for now I think we should use a combination of the "dependencies up to date" badge and specifying the version of OpenTelemetry manually in the README.

