### PR TITLE
Phillip's petty code changes to be more idiomatic

### DIFF
--- a/src/Honeycomb.OpenTelemetry/BaggageSpanProcessor.cs
+++ b/src/Honeycomb.OpenTelemetry/BaggageSpanProcessor.cs
@@ -12,7 +12,7 @@ namespace Honeycomb.OpenTelemetry
         /// <inheritdoc />
         public override void OnStart(Activity activity)
         {
-            foreach (KeyValuePair<string, string> entry in Baggage.Current)
+            foreach (var entry in Baggage.Current)
             {
                 activity.SetTag(entry.Key, entry.Value);
             }

--- a/src/Honeycomb.OpenTelemetry/ConsoleTraceLinkExporter.cs
+++ b/src/Honeycomb.OpenTelemetry/ConsoleTraceLinkExporter.cs
@@ -28,7 +28,8 @@ namespace Honeycomb.OpenTelemetry
         {
             _apiKey = options.ApiKey;
             _serviceName = options.ServiceName;
-            try {
+            try
+            {
                 InitTraceLinkParameters();
             }
             catch (Exception)
@@ -40,14 +41,17 @@ namespace Honeycomb.OpenTelemetry
         private void InitTraceLinkParameters()
         {
             if (string.IsNullOrEmpty(_apiKey))
+            {
                 return;
+            }
 
             var httpClient = new HttpClient();
             httpClient.BaseAddress = new Uri(ApiHost);
             httpClient.DefaultRequestHeaders.Add("X-Honeycomb-Team", _apiKey);
 
             var response = httpClient.GetAsync("/1/auth").GetAwaiter().GetResult();
-            if (!response.IsSuccessStatusCode) {
+            if (!response.IsSuccessStatusCode)
+            {
                 Console.WriteLine("WARN: Didn't get a valid response from Honeycomb");
                 return;
             }
@@ -57,7 +61,8 @@ namespace Honeycomb.OpenTelemetry
             _environmentSlug = authResponse.Environment.Slug;
             _teamSlug = authResponse.Team.Slug;
             if (string.IsNullOrEmpty(_environmentSlug) ||
-                string.IsNullOrEmpty(_teamSlug)) {
+                string.IsNullOrEmpty(_teamSlug))
+            {
                 Console.WriteLine("WARN: Team or Environment wasn't returned");
                 return;                
             }
@@ -67,8 +72,10 @@ namespace Honeycomb.OpenTelemetry
         /// <inheritdoc />
         public override ExportResult Export(in Batch<Activity> batch)
         {
-            if (!IsEnabled)
+            if (!IsEnabled) 
+            {
                 return ExportResult.Success;
+            }
 
             foreach (var activity in batch)
             {
@@ -81,13 +88,10 @@ namespace Honeycomb.OpenTelemetry
             return ExportResult.Success;
         }
 
-        private string GetTraceLink(string traceId)
-        {
-            if (_apiKey.Length == 32)
-               return $"http://ui.honeycomb.io/{_teamSlug}/datasets/{_serviceName}/trace?trace_id={traceId}";
-
-            return $"http://ui.honeycomb.io/{_teamSlug}/environments/{_environmentSlug}/datasets/{_serviceName}/trace?trace_id={traceId}";
-        }
+        private string GetTraceLink(string traceId) =>
+            _apiKey.Length == 32
+                ? $"http://ui.honeycomb.io/{_teamSlug}/datasets/{_serviceName}/trace?trace_id={traceId}"
+                : $"http://ui.honeycomb.io/{_teamSlug}/environments/{_environmentSlug}/datasets/{_serviceName}/trace?trace_id={traceId}";
     }
 
     internal class AuthResponse

--- a/src/Honeycomb.OpenTelemetry/EnvironmentOptions.cs
+++ b/src/Honeycomb.OpenTelemetry/EnvironmentOptions.cs
@@ -45,7 +45,7 @@ namespace Honeycomb.OpenTelemetry
             var value = _environmentService[key];
             if (value is string str && !string.IsNullOrWhiteSpace(str))
             {
-                return (string)value;
+                return str;
             }
 
             return defaultValue;

--- a/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
+++ b/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
@@ -28,7 +28,6 @@ namespace Honeycomb.OpenTelemetry
         private string _tracesDataset;
         private string _tracesEndpoint;
         private string _metricsEndpoint;
-        private bool _enableLocalVisualizations;
 
         /// <summary>
         /// Name of the Honeycomb section of IConfiguration
@@ -54,29 +53,23 @@ namespace Honeycomb.OpenTelemetry
         /// <summary>
         /// Returns whether API key used to send trace telemetry is a legacy key.
         /// </summary>
-        internal bool IsTracesLegacyKey()
-        {
-            // legacy key has 32 characters
-            return TracesApiKey?.Length == 32;
-        }
+        /// <remarks>
+        /// Legacy keys have 32 characters.
+        /// </remarks>
+        internal bool IsTracesLegacyKey() => TracesApiKey?.Length == 32;
 
         /// <summary>
         /// Returns whether API key used to send metrics telemetry is a legacy key.
         /// </summary>
-        internal bool IsMetricsLegacyKey()
-        {
-            // legacy key has 32 characters
-            return MetricsApiKey?.Length == 32;
-        }
+        /// <remarks>
+        /// Legacy keys have 32 characters.
+        /// </remarks>
+        internal bool IsMetricsLegacyKey() => MetricsApiKey?.Length == 32;
 
         /// <summary>
         /// Write links to honeycomb traces as they come in
         /// </summary>
-        public bool EnableLocalVisualizations
-        { 
-            get { return _enableLocalVisualizations; } 
-            set { _enableLocalVisualizations = value; }
-        }
+        public bool EnableLocalVisualizations { get; set; } = false;
 
         /// <summary>
         /// API key used to send trace telemetry data to Honeycomb. Defaults to <see cref="ApiKey"/>.
@@ -101,7 +94,6 @@ namespace Honeycomb.OpenTelemetry
         /// <para/>
         /// </summary>
         public string Dataset { get; set; }
-
 
         /// <summary>
         /// Honeycomb dataset to store trace telemetry data. Defaults to <see cref="Dataset"/>.
@@ -153,7 +145,7 @@ namespace Honeycomb.OpenTelemetry
         /// <summary>
         /// Service name used to identify application. Defaults to unknown_process:processname.
         /// </summary>
-        public string ServiceName { get; set; }
+        public string ServiceName { get; set; } = SDefaultServiceName;
 
         /// <summary>
         /// Service version. Defaults to application assembly information version.
@@ -249,8 +241,7 @@ namespace Honeycomb.OpenTelemetry
             var config = new ConfigurationBuilder()
                 .AddCommandLine(args, CommandLineSwitchMap)
                 .Build();
-            var honeycombOptions = config
-                .Get<HoneycombOptions>();
+            var honeycombOptions = config.Get<HoneycombOptions>();
 
             var meterNames = config.GetValue<string>("meternames");
             if (!string.IsNullOrWhiteSpace(meterNames))

--- a/src/Honeycomb.OpenTelemetry/HoneycombOptionsExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry/HoneycombOptionsExtensions.cs
@@ -11,11 +11,15 @@ namespace Honeycomb.OpenTelemetry {
                 $"x-otlp-version={OtlpVersion}",
                 $"x-honeycomb-team={options.TracesApiKey}"
             };
-            if (options.IsTracesLegacyKey()) {
+            if (options.IsTracesLegacyKey())
+            {
                 // if the key is legacy, add dataset to the header
-                if (!string.IsNullOrWhiteSpace(options.TracesDataset)) {
+                if (!string.IsNullOrWhiteSpace(options.TracesDataset))
+                {
                     headers.Add($"x-honeycomb-dataset={options.TracesDataset}");
-                } else {
+                }
+                else
+                {
                     // if legacy key and missing dataset, warn on missing dataset
                     Console.WriteLine($"WARN: {EnvironmentOptions.GetErrorMessage("dataset", "HONEYCOMB_DATASET")}.");
                 }

--- a/src/Honeycomb.OpenTelemetry/MeterProviderBuilderExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry/MeterProviderBuilderExtensions.cs
@@ -37,7 +37,10 @@ namespace Honeycomb.OpenTelemetry
             if (!string.IsNullOrWhiteSpace(options.MetricsDataset))
             {
                 if (string.IsNullOrWhiteSpace(options.MetricsApiKey))
+                {
                     Console.WriteLine("WARN: missing metrics API key");
+                }
+                
                 builder
                     .SetResourceBuilder(
                         ResourceBuilder

--- a/src/Honeycomb.OpenTelemetry/ServiceCollectionExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry/ServiceCollectionExtensions.cs
@@ -55,10 +55,12 @@ namespace Honeycomb.OpenTelemetry
                                 opts.Enrich = (activity, eventName, _) =>
                                 {
                                     if (eventName == "OnStartActivity")
-                                        foreach (KeyValuePair<string, string> entry in Baggage.Current)
+                                    {
+                                        foreach (var entry in Baggage.Current)
                                         {
                                             activity.SetTag(entry.Key, entry.Value);
                                         }
+                                    }
                                 };
                             });
                     }))

--- a/src/Honeycomb.OpenTelemetry/TracerProviderBuilderExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry/TracerProviderBuilderExtensions.cs
@@ -132,10 +132,12 @@ namespace Honeycomb.OpenTelemetry
                 opts.Enrich = (activity, eventName, _) =>
                 {
                     if (eventName == "OnStartActivity")
-                        foreach (KeyValuePair<string, string> entry in Baggage.Current)
+                    {
+                        foreach (var entry in Baggage.Current)
                         {
                             activity.SetTag(entry.Key, entry.Value);
                         }
+                    }
                 });
 #endif
 


### PR DESCRIPTION
This is not an important PR, so don't feel obligated to treat it as important. But it does bring up the codebase to modern C# code formatting and style standards (to the extent that it can - can't replace `SubString` with ranges due to the netframework target).