### PR TITLE
Attempt to match Java distro resources

### DIFF
--- a/src/Honeycomb.OpenTelemetry/ResourceBuilderExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry/ResourceBuilderExtensions.cs
@@ -28,6 +28,12 @@ namespace Honeycomb.OpenTelemetry
                 .AddOSResource();
         }
 
+        /// <summary>
+        /// Determines process runtime resources and adds them to the <see cref="ResourceBuilder"/>.
+        /// </summary>
+        /// <remarks>
+        /// See https://opentelemetry.io/docs/reference/specification/resource/semantic_conventions/process/#process-runtimes
+        /// </remarks>
         private static ResourceBuilder AddRuntimeResource(this ResourceBuilder builder)
         {
             var frameworkDescription = RuntimeInformation.FrameworkDescription;
@@ -35,9 +41,6 @@ namespace Honeycomb.OpenTelemetry
             var runtimeName = "unknown";
             var runtimeVersion = "unknown";
 
-            // See here:
-            // https://docs.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.runtimeinformation.frameworkdescription?view=netstandard-2.0
-            // Description likely cannot be synthesized, at least not easily.
             if (!frameworkDescription.StartsWith(".NET"))
             {
                 return builder;
@@ -55,6 +58,7 @@ namespace Honeycomb.OpenTelemetry
             }
             else if (frameworkDescription.StartsWith(".NET Native"))
             {
+                // I doubt we'll ever see a user match this, but it's a valid runtime, so...
                 runtimeName = ".NET Native";
                 runtimeVersion = frameworkDescription.Substring(".NET Native".Length);
             }
@@ -67,7 +71,6 @@ namespace Honeycomb.OpenTelemetry
             return builder
                 .AddAttributes(new List<KeyValuePair<string, object>>
                 {
-                    
                     new KeyValuePair<string, object>("process.runtime.name", runtimeName),
                     new KeyValuePair<string, object>("process.runtime.version", runtimeVersion)
                 });

--- a/src/Honeycomb.OpenTelemetry/ResourceBuilderExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry/ResourceBuilderExtensions.cs
@@ -1,5 +1,6 @@
 using OpenTelemetry.Resources;
 using System;
+using System.Runtime.InteropServices;
 using System.Collections.Generic;
 using System.Reflection;
 
@@ -22,6 +23,56 @@ namespace Honeycomb.OpenTelemetry
                     new KeyValuePair<string, object>("honeycomb.distro.version", GetFileVersion()),
                     new KeyValuePair<string, object>("honeycomb.distro.runtime_version",
                         Environment.Version.ToString()),
+                })
+                .AddRuntimeResource()
+                .AddOSResource();
+        }
+
+        private static ResourceBuilder AddRuntimeResource(this ResourceBuilder builder)
+        {
+            var frameworkDescription = RuntimeInformation.FrameworkDescription;
+            var parts = frameworkDescription.Split(' ');
+            return builder
+                .AddAttributes(new List<KeyValuePair<string, object>>
+                {
+                    // See here:
+                    // https://docs.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.runtimeinformation.frameworkdescription?view=netstandard-2.0
+                    // Description likely cannot be synthesized, at least not easily.
+                    new KeyValuePair<string, object>("process.runtime.name", parts[0]),
+                    new KeyValuePair<string, object>("process.runtime.version", parts[1])
+                });
+        }
+
+        private static ResourceBuilder AddOSResource(this ResourceBuilder builder)
+        {
+            var osType = "unknown";
+            var osName = "unknown";
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                osType = "windows";
+                osName = "Windows";
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                osType = "linux";
+                osName = "Linux";
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                osType = "darwin";
+                osName = "macOS";
+            }
+
+            var versionWithPotentialWindowsServicePack = Environment.OSVersion.VersionString.IndexOf(" ") + 1;
+            return builder
+                .AddAttributes(new List<KeyValuePair<string, object>>
+                {
+                    new KeyValuePair<string, object>("os.type", osType),
+                    new KeyValuePair<string, object>("os.description",
+                        Environment.OSVersion.VersionString),
+                    new KeyValuePair<string, object>("os.name", osName),
+                    new KeyValuePair<string, object>("os.version",
+                        Environment.OSVersion.VersionString.Substring(versionWithPotentialWindowsServicePack)),
                 });
         }
 

--- a/src/Honeycomb.OpenTelemetry/ResourceBuilderExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry/ResourceBuilderExtensions.cs
@@ -31,15 +31,45 @@ namespace Honeycomb.OpenTelemetry
         private static ResourceBuilder AddRuntimeResource(this ResourceBuilder builder)
         {
             var frameworkDescription = RuntimeInformation.FrameworkDescription;
-            var parts = frameworkDescription.Split(' ');
+
+            var runtimeName = "unknown";
+            var runtimeVersion = "unknown";
+
+            // See here:
+            // https://docs.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.runtimeinformation.frameworkdescription?view=netstandard-2.0
+            // Description likely cannot be synthesized, at least not easily.
+            if (!frameworkDescription.StartsWith(".NET"))
+            {
+                return builder;
+            }
+
+            if (frameworkDescription.StartsWith(".NET Core"))
+            {
+                runtimeName = ".NET Core";
+                runtimeVersion = frameworkDescription.Substring(".NET Core".Length);
+            }
+            else if (frameworkDescription.StartsWith(".NET Framework"))
+            {
+                runtimeName = ".NET Framework";
+                runtimeVersion = frameworkDescription.Substring(".NET Framework".Length);
+            }
+            else if (frameworkDescription.StartsWith(".NET Native"))
+            {
+                runtimeName = ".NET Native";
+                runtimeVersion = frameworkDescription.Substring(".NET Native".Length);
+            }
+            else
+            {
+                runtimeName = ".NET";
+                runtimeVersion = frameworkDescription.Substring(".NET".Length);
+            }
+
             return builder
                 .AddAttributes(new List<KeyValuePair<string, object>>
                 {
-                    // See here:
-                    // https://docs.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.runtimeinformation.frameworkdescription?view=netstandard-2.0
-                    // Description likely cannot be synthesized, at least not easily.
-                    new KeyValuePair<string, object>("process.runtime.name", parts[0]),
-                    new KeyValuePair<string, object>("process.runtime.version", parts[1])
+                    
+                    new KeyValuePair<string, object>("process.runtime.name", runtimeName),
+                    new KeyValuePair<string, object>("process.runtime.version", runtimeVersion)
                 });
         }
 


### PR DESCRIPTION
I think this gets us as close as we can with https://github.com/honeycombio/honeycomb-opentelemetry-dotnet/issues/119 given the following constraints:

* Can't use the new .NET 6 APIs that give you much richer OS and runtime information
* Can't rely on upstream OTel, since they don't have these resources implemented in the SDK
* Can't rely on pre-defined values for runtime info from upstream since [they aren't specified](https://github.com/open-telemetry/opentelemetry-dotnet/issues/1281)

That said, I think it's valuable to have _something_ rather than nothing.