### PR TITLE
Support debug option

### DIFF
--- a/src/Honeycomb.OpenTelemetry/EnvironmentOptions.cs
+++ b/src/Honeycomb.OpenTelemetry/EnvironmentOptions.cs
@@ -17,6 +17,7 @@ namespace Honeycomb.OpenTelemetry
         private const string ServiceNameKey = "OTEL_SERVICE_NAME";
         private const string ServiceVersionKey = "SERVICE_VERSION";
         private const string EnableLocalVisualizationsKey = "ENABLE_LOCAL_VISUALIZATIONS";
+        private const string DebugKey = "DEBUG";
         private const uint DefaultSampleRate = 1;
         private const string DefaultApiEndpoint = "https://api.honeycomb.io:443";
         private readonly IDictionary _environmentService;
@@ -38,6 +39,7 @@ namespace Honeycomb.OpenTelemetry
         internal string ServiceName => GetEnvironmentVariable(ServiceNameKey);
         internal string ServiceVersion => GetEnvironmentVariable(ServiceVersionKey);
         internal bool EnableLocalVisualizations => bool.TryParse(GetEnvironmentVariable(EnableLocalVisualizationsKey), out var enableLocalVisualizations) ? enableLocalVisualizations : false;
+        internal bool Debug => bool.TryParse(GetEnvironmentVariable(DebugKey), out var debug) ? debug : false;
         internal uint SampleRate => uint.TryParse(GetEnvironmentVariable(SampleRateKey), out var sampleRate) ? sampleRate : DefaultSampleRate;
 
         private string GetEnvironmentVariable(string key, string defaultValue = "")

--- a/src/Honeycomb.OpenTelemetry/Honeycomb.OpenTelemetry.csproj
+++ b/src/Honeycomb.OpenTelemetry/Honeycomb.OpenTelemetry.csproj
@@ -30,9 +30,6 @@
     <PackageReference Include="OpenTelemetry" Version="1.3.1" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.3.1" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.3.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.4" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.0.0-rc9.4" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.0.0-rc9.4" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />

--- a/src/Honeycomb.OpenTelemetry/Honeycomb.OpenTelemetry.csproj
+++ b/src/Honeycomb.OpenTelemetry/Honeycomb.OpenTelemetry.csproj
@@ -27,8 +27,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="1.3.0 " />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.3.0" />
+    <PackageReference Include="OpenTelemetry" Version="1.3.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.3.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.3.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.4" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.0.0-rc9.4" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.0.0-rc9.4" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />

--- a/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
+++ b/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
@@ -179,6 +179,12 @@ namespace Honeycomb.OpenTelemetry
         /// Determines whether the <see cref="DeterministicSampler"/> sampler is added when configuring a <see cref="TracerProviderBuilder"/>.
         /// </summary>
         public bool AddDeterministicSampler { get; set; } = true;
+
+        /// <summary>
+        /// If set to true, enables the console span exporter for local debugging.
+        /// </summary>
+        public bool Debug { get; set; } = false;
+        
         private static readonly Dictionary<string, string> CommandLineSwitchMap = new Dictionary<string, string>
         {
             { "--honeycomb-apikey", "apikey" },

--- a/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
+++ b/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
@@ -202,7 +202,8 @@ namespace Honeycomb.OpenTelemetry
             { "--honeycomb-add-determinisitc-sampler", "addDeterministicSampler" },
             { "--service-name", "servicename" },
             { "--service-version", "serviceversion" },
-            { "--meter-names", "meternames" }
+            { "--meter-names", "meternames" },
+            { "--debug", "debug" }
         };
 
         /// <summary>

--- a/src/Honeycomb.OpenTelemetry/MeterProviderBuilderExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry/MeterProviderBuilderExtensions.cs
@@ -56,6 +56,11 @@ namespace Honeycomb.OpenTelemetry
                 {
                     builder.AddMeter(meterName);
                 }
+
+                if (options.Debug)
+                {
+                    builder.AddConsoleExporter();
+                }
             }
 
             return builder;

--- a/src/Honeycomb.OpenTelemetry/TracerProviderBuilderExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry/TracerProviderBuilderExtensions.cs
@@ -107,6 +107,11 @@ namespace Honeycomb.OpenTelemetry
                 builder.AddProcessor(new SimpleActivityExportProcessor(new ConsoleTraceLinkExporter(options)));
             }
 
+            if (options.Debug)
+            {
+                builder.AddConsoleExporter();
+            }
+
             // heads up: even if dataset is set, it will be ignored
             if (!string.IsNullOrWhiteSpace(options.TracesApiKey) & !options.IsTracesLegacyKey() & (!string.IsNullOrWhiteSpace(options.TracesDataset)))
             {

--- a/test/Honeycomb.OpenTelemetry.Tests/EnvironmentOptionsTests.cs
+++ b/test/Honeycomb.OpenTelemetry.Tests/EnvironmentOptionsTests.cs
@@ -22,7 +22,8 @@ namespace Honeycomb.OpenTelemetry
                 {"HONEYCOMB_SAMPLE_RATE", "10"},
                 {"OTEL_SERVICE_NAME", "my-service-name"},
                 {"SERVICE_VERSION", "my-service-version"},
-                {"ENABLE_LOCAL_VISUALIZATIONS", "true" }
+                {"ENABLE_LOCAL_VISUALIZATIONS", "true" },
+                {"DEBUG", "true"}
             };
             var options = new EnvironmentOptions(values);
             Assert.Equal("my-api-key", options.ApiKey);
@@ -38,6 +39,7 @@ namespace Honeycomb.OpenTelemetry
             Assert.Equal("my-service-name", options.ServiceName);
             Assert.Equal("my-service-version", options.ServiceVersion);
             Assert.True(options.EnableLocalVisualizations);
+            Assert.True(options.Debug);
         }
 
         [Fact]

--- a/test/Honeycomb.OpenTelemetry.Tests/HoneycombOptionsTests.cs
+++ b/test/Honeycomb.OpenTelemetry.Tests/HoneycombOptionsTests.cs
@@ -25,6 +25,7 @@ namespace Honeycomb.OpenTelemetry.Tests
             Assert.Equal(HoneycombOptions.DefaultEndpoint, options.TracesEndpoint);
             Assert.Equal(HoneycombOptions.DefaultEndpoint, options.MetricsEndpoint);
             Assert.Empty(options.MeterNames);
+            Assert.False(options.Debug);
         }
 
         [Fact]
@@ -43,7 +44,8 @@ namespace Honeycomb.OpenTelemetry.Tests
                 "--honeycomb-metrics-endpoint", "my-metrics-endpoint",
                 "--meter-names", "meter1,meter2",
                 "--service-name", "my-service",
-                "--service-version", "my-version"
+                "--service-version", "my-version",
+                "--debug", "true"
             );
 
             Assert.Equal("my-apikey", options.ApiKey);
@@ -59,6 +61,7 @@ namespace Honeycomb.OpenTelemetry.Tests
             Assert.Equal("my-service", options.ServiceName);
             Assert.Equal("my-version", options.ServiceVersion);
             Assert.Equal(new List<string> { "meter1", "meter2" }, options.MeterNames);
+            Assert.True(options.Debug);
         }
 
         [Fact]
@@ -77,7 +80,8 @@ namespace Honeycomb.OpenTelemetry.Tests
                 "--honeycomb-metrics-endpoint=my-metrics-endpoint",
                 "--meter-names=meter1,meter2",
                 "--service-name=my-service",
-                "--service-version=my-version"
+                "--service-version=my-version",
+                "--debug=true"
             );
 
             Assert.Equal("my-apikey", options.ApiKey);
@@ -93,6 +97,7 @@ namespace Honeycomb.OpenTelemetry.Tests
             Assert.Equal("my-service", options.ServiceName);
             Assert.Equal("my-version", options.ServiceVersion);
             Assert.Equal(new List<string> { "meter1", "meter2" }, options.MeterNames);
+            Assert.True(options.Debug);
         }
 
         [Fact]
@@ -120,6 +125,7 @@ namespace Honeycomb.OpenTelemetry.Tests
             Assert.Equal("my-version", options.ServiceVersion);
             Assert.Equal(new List<string> { "meter1", "meter2" }, options.MeterNames);
             Assert.True(options.EnableLocalVisualizations);
+            Assert.True(options.Debug);
         }
 
         [Fact]

--- a/test/Honeycomb.OpenTelemetry.Tests/appsettings.test.json
+++ b/test/Honeycomb.OpenTelemetry.Tests/appsettings.test.json
@@ -16,6 +16,7 @@
     ],
     "ServiceName": "my-service",
     "ServiceVersion": "my-version",
-    "EnableLocalVisualizations": true
+    "EnableLocalVisualizations": true,
+    "Debug": true
   }
 }


### PR DESCRIPTION
- Closes https://github.com/honeycombio/honeycomb-opentelemetry-dotnet/issues/253
- Resolves #61

Note that because of https://github.com/honeycombio/honeycomb-opentelemetry-dotnet/issues/46, this is harder to test out in various ways. But here's an example of using it from code:

```
λ ~/repos/honeycomb-opentelemetry-dotnet/ cartermp/debug* dotnet run --project examples/console
Resource associated with Metric:
    service.name: phillips-happy-fun-time
    service.version: {unknown_service_version}
    service.instance.id: 700ca5d0-1b13-4b10-94b4-e2ecd6552499
    os.type: darwin
    os.description: Unix 12.5.1
    os.name: macOS
    os.version: 12.5.1
    process.runtime.name: .NET
    process.runtime.version:  6.0.8
    honeycomb.distro.language: dotnet
    honeycomb.distro.version: 0.23.0-beta
    honeycomb.distro.runtime_version: 6.0.8

Export sheep, Meter: phillips-happy-fun-time
(2022-09-20T00:43:53.5647680Z, 2022-09-20T00:43:54.0341820Z] LongSum
Value: 1
Activity.TraceId:          e43694bacee8508c4b777c607b3316bf
Activity.SpanId:           f2d7263e925a39a1
Activity.TraceFlags:           Recorded
Activity.ActivitySourceName: phillips-happy-fun-time
Activity.DisplayName: doSomething
Activity.Kind:        Internal
Activity.StartTime:   2022-09-20T00:43:53.5489160Z
Activity.Duration:    00:00:00.4930540
Activity.Tags:
    SampleRate: 1
    user_id: 123
Resource associated with Activity:
    service.name: phillips-happy-fun-time
    service.version: {unknown_service_version}
    service.instance.id: 06dd9176-f417-4511-8dbf-7e72f6c624a4
    os.type: darwin
    os.description: Unix 12.5.1
    os.name: macOS
    os.version: 12.5.1
    process.runtime.name: .NET
    process.runtime.version:  6.0.8
    honeycomb.distro.language: dotnet
    honeycomb.distro.version: 0.23.0-beta
    honeycomb.distro.runtime_version: 6.0.8
    my-attribute: some-value
```

And the corresponding trace/metric is in the 