### PR TITLE
Set options with env vars if they're present

### DIFF
--- a/src/Honeycomb.OpenTelemetry/EnvironmentOptions.cs
+++ b/src/Honeycomb.OpenTelemetry/EnvironmentOptions.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Collections.Generic;
 
 namespace Honeycomb.OpenTelemetry
 {
@@ -22,6 +23,7 @@ namespace Honeycomb.OpenTelemetry
         private const string DefaultApiEndpoint = "https://api.honeycomb.io:443";
         private readonly IDictionary _environmentService;
 
+        internal EnvironmentOptions() => new EnvironmentOptions(new Dictionary<string, string>());
         internal EnvironmentOptions(IDictionary service)
         {
             _environmentService = service;
@@ -41,6 +43,79 @@ namespace Honeycomb.OpenTelemetry
         internal bool EnableLocalVisualizations => bool.TryParse(GetEnvironmentVariable(EnableLocalVisualizationsKey), out var enableLocalVisualizations) ? enableLocalVisualizations : false;
         internal bool Debug => bool.TryParse(GetEnvironmentVariable(DebugKey), out var debug) ? debug : false;
         internal uint SampleRate => uint.TryParse(GetEnvironmentVariable(SampleRateKey), out var sampleRate) ? sampleRate : DefaultSampleRate;
+
+        internal void SetOptionsFromEnvironmentIfTheyExist(HoneycombOptions options)
+        {
+            if (!string.IsNullOrWhiteSpace(ApiKey))
+            {
+                options.ApiKey = ApiKey;
+            }
+
+            if (!string.IsNullOrWhiteSpace(TracesApiKey))
+            {
+                options.TracesApiKey = TracesApiKey;
+            }
+
+            if (!string.IsNullOrWhiteSpace(MetricsApiKey))
+            {
+                options.MetricsApiKey = MetricsApiKey;
+            }
+
+            if (!string.IsNullOrWhiteSpace(Dataset))
+            {
+                options.Dataset = Dataset;
+            }
+
+            if (!string.IsNullOrWhiteSpace(TracesDataset))
+            {
+                options.TracesDataset = TracesDataset;
+            }
+
+            if (!string.IsNullOrWhiteSpace(MetricsDataset))
+            {
+                options.MetricsDataset = MetricsDataset;
+            }
+
+            if (!string.IsNullOrWhiteSpace(ApiEndpoint))
+            {
+                options.Endpoint = ApiEndpoint;
+            }
+
+            if (!string.IsNullOrWhiteSpace(TracesEndpoint))
+            {
+                options.TracesEndpoint = TracesEndpoint;
+            }
+
+            if (!string.IsNullOrWhiteSpace(MetricsEndpoint))
+            {
+                options.MetricsEndpoint = MetricsEndpoint;
+            }
+
+            if (!string.IsNullOrWhiteSpace(ServiceName))
+            {
+                options.ServiceName = ServiceName;
+            }
+
+            if (!string.IsNullOrWhiteSpace(ServiceVersion))
+            {
+                options.ServiceVersion = ServiceVersion;
+            }
+
+            if (!options.EnableLocalVisualizations)
+            {
+                options.EnableLocalVisualizations = EnableLocalVisualizations;
+            }
+
+            if (!options.Debug)
+            {
+                options.Debug = Debug;
+            }
+
+            if (options.SampleRate == DefaultSampleRate)
+            {
+                options.SampleRate = SampleRate;
+            }
+        }
 
         private string GetEnvironmentVariable(string key, string defaultValue = "")
         {

--- a/src/Honeycomb.OpenTelemetry/EnvironmentOptions.cs
+++ b/src/Honeycomb.OpenTelemetry/EnvironmentOptions.cs
@@ -101,19 +101,19 @@ namespace Honeycomb.OpenTelemetry
                 options.ServiceVersion = ServiceVersion;
             }
 
-            if (!options.EnableLocalVisualizations)
+            if (bool.TryParse(GetEnvironmentVariable(EnableLocalVisualizationsKey), out var enableLocalVisualizations))
             {
-                options.EnableLocalVisualizations = EnableLocalVisualizations;
+                options.EnableLocalVisualizations = enableLocalVisualizations;
             }
 
-            if (!options.Debug)
+            if (bool.TryParse(GetEnvironmentVariable(DebugKey), out var debug))
             {
-                options.Debug = Debug;
+                options.Debug = debug;
             }
 
-            if (options.SampleRate == DefaultSampleRate)
+            if (uint.TryParse(GetEnvironmentVariable(SampleRateKey), out var sampleRate))
             {
-                options.SampleRate = SampleRate;
+                options.SampleRate = sampleRate;
             }
         }
 

--- a/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
+++ b/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
@@ -225,16 +225,16 @@ namespace Honeycomb.OpenTelemetry
             return honeycombOptions;
         }
 
-        internal string GetTraceHeaders() {
-            return GetTraceHeaders(TracesApiKey, TracesDataset);
-        }
+        internal string GetTraceHeaders() => GetTraceHeaders(TracesApiKey, TracesDataset);
 
-        internal static string GetTraceHeaders(string apikey, string dataset) {
+        internal static string GetTraceHeaders(string apikey, string dataset)
+        {
             var headers = new List<string>
             {
                 $"x-otlp-version={OtlpVersion}",
                 $"x-honeycomb-team={apikey}"
             };
+
             if (IsClassicKey(apikey))
             {
                 // if the key is legacy, add dataset to the header
@@ -248,21 +248,21 @@ namespace Honeycomb.OpenTelemetry
                     Console.WriteLine($"WARN: {EnvironmentOptions.GetErrorMessage("dataset", "HONEYCOMB_DATASET")}.");
                 }
             }
+
             return string.Join(",", headers);
         }
 
-        internal string GetMetricsHeaders()
-        {
-            return GetMetricsHeaders(MetricsApiKey, MetricsDataset);
-        }
+        internal string GetMetricsHeaders() => GetMetricsHeaders(MetricsApiKey, MetricsDataset);
 
-        internal static string GetMetricsHeaders(string apikey, string dataset) {
+        internal static string GetMetricsHeaders(string apikey, string dataset)
+        {
             var headers = new List<string>
             {
                 $"x-otlp-version={OtlpVersion}",
                 $"x-honeycomb-team={apikey}",
                 $"x-honeycomb-dataset={dataset}"
             };
+            
             return string.Join(",", headers);
         }
     }

--- a/src/Honeycomb.OpenTelemetry/TracerProviderBuilderExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry/TracerProviderBuilderExtensions.cs
@@ -58,14 +58,8 @@ namespace Honeycomb.OpenTelemetry
                 throw new ArgumentNullException(nameof(options), "No Honeycomb options have been set in appsettings.json, environment variables, or the command line.");
             }
 
-            // TODO: Add support for other environment variables
             var environmentOptions = new EnvironmentOptions(Environment.GetEnvironmentVariables());
-
-            // if service name set in environment, prioritize it
-            if (!string.IsNullOrWhiteSpace(environmentOptions.ServiceName))
-            {
-                options.ServiceName = environmentOptions.ServiceName;
-            }
+            environmentOptions.SetOptionsFromEnvironmentIfTheyExist(options);
 
             // if serviceName is null, warn and set to default
             if (string.IsNullOrWhiteSpace(options.ServiceName))

--- a/test/Honeycomb.OpenTelemetry.Tests/EnvironmentOptionsTests.cs
+++ b/test/Honeycomb.OpenTelemetry.Tests/EnvironmentOptionsTests.cs
@@ -43,6 +43,61 @@ namespace Honeycomb.OpenTelemetry
         }
 
         [Fact]
+        public void EnvironmentOptionsCanOverrideHoneycombOptions()
+        {
+            var honeycombOptions = new HoneycombOptions
+            {
+                ApiKey = "my-api-key",
+                TracesApiKey = "my-traces-api-key",
+                MetricsApiKey = "my-metrics-api-key",
+                Dataset = "my-dataset",
+                TracesDataset = "my-traces-dataset",
+                MetricsDataset = "my-metrics-dataset",
+                Endpoint = "my-endpoint",
+                TracesEndpoint = "my-traces-endpoint",
+                MetricsEndpoint = "my-metrics-endpoint",
+                SampleRate = 2,
+                ServiceName = "my-service-name",
+                ServiceVersion = "my-service-version",
+                EnableLocalVisualizations = false,
+                Debug = false
+            };
+
+            var values = new Dictionary<string, string>
+            {
+                {"HONEYCOMB_API_KEY", "my-env-api-key"},
+                {"HONEYCOMB_TRACES_API_KEY", "my-env-traces-api-key"},
+                {"HONEYCOMB_METRICS_API_KEY", "my-env-metrics-api-key"},
+                {"HONEYCOMB_DATASET", "my-env-dataset"},
+                {"HONEYCOMB_TRACES_DATASET", "my-env-traces-dataset"},
+                {"HONEYCOMB_METRICS_DATASET", "my-env-metrics-dataset"},
+                {"HONEYCOMB_API_ENDPOINT", "my-env-endpoint"},
+                {"HONEYCOMB_TRACES_ENDPOINT", "my-env-traces-endpoint"},
+                {"HONEYCOMB_METRICS_ENDPOINT", "my-env-metrics-endpoint"},
+                {"HONEYCOMB_SAMPLE_RATE", "10"},
+                {"OTEL_SERVICE_NAME", "my-env-service-name"},
+                {"SERVICE_VERSION", "my-env-service-version"},
+                {"ENABLE_LOCAL_VISUALIZATIONS", "true" },
+                {"DEBUG", "true"}
+            };
+            var options = new EnvironmentOptions(values);
+            Assert.Equal("my-env-api-key", options.ApiKey);
+            Assert.Equal("my-env-traces-api-key", options.TracesApiKey);
+            Assert.Equal("my-env-metrics-api-key", options.MetricsApiKey);
+            Assert.Equal("my-env-dataset", options.Dataset);
+            Assert.Equal("my-env-traces-dataset", options.TracesDataset);
+            Assert.Equal("my-env-metrics-dataset", options.MetricsDataset);
+            Assert.Equal("my-env-endpoint", options.ApiEndpoint);
+            Assert.Equal("my-env-traces-endpoint", options.TracesEndpoint);
+            Assert.Equal("my-env-metrics-endpoint", options.MetricsEndpoint);
+            Assert.Equal((uint)10, options.SampleRate);
+            Assert.Equal("my-env-service-name", options.ServiceName);
+            Assert.Equal("my-env-service-version", options.ServiceVersion);
+            Assert.True(options.EnableLocalVisualizations);
+            Assert.True(options.Debug);
+        }
+
+        [Fact]
         public void Optional_args_fall_back_to_defaults()
         {
             var options = new EnvironmentOptions(new Dictionary<string, string>());


### PR DESCRIPTION
This should fix https://github.com/honeycombio/honeycomb-opentelemetry-dotnet/issues/248