### PR TITLE
Add Tracer to DI in AspNetCore examples

### DIFF
--- a/examples/aspnetcore-redis/Startup.cs
+++ b/examples/aspnetcore-redis/Startup.cs
@@ -41,11 +41,13 @@ namespace aspnetcoreredis
             services.AddSingleton<IConnectionMultiplexer>(redis);
 
             // configure OpenTelemetry SDK to send data to Honeycomb
+            var options = Configuration.GetSection(HoneycombOptions.ConfigSectionName).Get<HoneycombOptions>();
             services.AddOpenTelemetryTracing(builder => builder
-                .AddHoneycomb(Configuration)
+                .AddHoneycomb(options)
                 .AddAspNetCoreInstrumentationWithBaggage()
                 .AddRedisInstrumentation(redis)
             );
+            services.AddSingleton(TracerProvider.Default.GetTracer(options.ServiceName));
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/examples/aspnetcore-redis/appsettings.json
+++ b/examples/aspnetcore-redis/appsettings.json
@@ -8,7 +8,7 @@
   },
   "AllowedHosts": "*",
   "Honeycomb": {
-    "ServiceName": "my-web-app-with-redis",
+    "ServiceName": "aspnetcore-redis-example",
     "ApiKey": "{apikey}"
   }
 }

--- a/examples/aspnetcore/Startup.cs
+++ b/examples/aspnetcore/Startup.cs
@@ -32,16 +32,18 @@ namespace aspnetcore
             services.AddControllers();
 
             // configure OpenTelemetry SDK to send data to Honeycomb
+            var options = Configuration.GetSection(HoneycombOptions.ConfigSectionName).Get<HoneycombOptions>();
             services.AddOpenTelemetryTracing(builder => builder
-                .AddHoneycomb(Configuration)
+                .AddHoneycomb(options)
                 .AddAspNetCoreInstrumentationWithBaggage()
             );
+            services.AddSingleton(TracerProvider.Default.GetTracer(options.ServiceName));
 
             // (optional metrics setup)
             // meter name used here must be configured in the OpenTelemetry SDK
             // service name is configured by default
             // you may configure additional meter names using the Honeycomb options
-            Meter meter = new Meter("my-web-app");
+            Meter meter = new Meter(options.MetricsDataset);
             services.AddSingleton(meter);
         }
 

--- a/examples/aspnetcore/appsettings.json
+++ b/examples/aspnetcore/appsettings.json
@@ -8,8 +8,8 @@
   },
   "AllowedHosts": "*",
   "Honeycomb": {
-    "ServiceName": "my-web-app",
+    "ServiceName": "aspnetcore-example",
     "ApiKey": "{apikey}",
-    "MetricsDataset": "my-web-app_metrics"
+    "MetricsDataset": "aspnetcore-example-metrics"
   }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
The examples failed to inject the tracer into their WeatherForecast controller because it wasn't registered in the IServiceCollection (DI). This does that and tidies up using configurations.

## Short description of the changes
- Updates examples to register Tracer in IServiceCollection during setup

