### PR TITLE
Add http/protobuf smoke tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -452,3 +452,9 @@ $RECYCLE.BIN/
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+
+### temporary smoke-test files
+smoke-tests/collector/data.json
+smoke-tests/collector/data-results/*.json
+smoke-tests/report.xml
+smoke-tests/report.html

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ smoke:
 	@echo ""
 	@echo "+++ Placeholder for Smoking all the tests."
 	@echo ""
-	cd smoke-tests && docker-compose up -d --build && docker-compose down --volumes
+	cd smoke-tests && docker-compose up -d --build collector app-sdk-http && docker-compose down --volumes
 
 unsmoke:
 	@echo ""

--- a/smoke-tests/docker-compose.yml
+++ b/smoke-tests/docker-compose.yml
@@ -6,7 +6,7 @@ x-env-base: &env_base
   HONEYCOMB_DATASET: bogus_dataset
   HONEYCOMB_METRICS_DATASET: bogus_dataset
   OTEL_METRIC_EXPORT_INTERVAL: 1000
-  SERVICE_NAME: "my-web-app"
+  OTEL_SERVICE_NAME: "aspnetcore-example"
 
 x-app-base: &app_base
   build:

--- a/smoke-tests/docker-compose.yml
+++ b/smoke-tests/docker-compose.yml
@@ -8,6 +8,14 @@ x-env-base: &env_base
   OTEL_METRIC_EXPORT_INTERVAL: 1000
   SERVICE_NAME: "my-web-app"
 
+x-app-base: &app_base
+  build:
+    context: ../
+    dockerfile: ./examples/aspnetcore/Dockerfile
+  image: honeycomb/aspnetcore
+  depends_on:
+    - collector
+
 services:
   collector:
     image: otel/opentelemetry-collector:0.52.0
@@ -17,11 +25,17 @@ services:
       - "./collector:/var/lib"
 
   app-aspnetcore:
-    build:
-      context: ../
-      dockerfile: ./examples/aspnetcore/Dockerfile
-    image: honeycomb/aspnetcore
+    <<: *app_base
     environment:
       <<: *env_base
+    ports:
+      - "127.0.0.1:5001:5001"
+  
+  app-sdk-http:
+    <<: *app_base
+    environment:
+      <<: *env_base
+      HONEYCOMB_API_ENDPOINT: http://collector:4318
+      OTEL_EXPORTER_OTLP_PROTOCOL: http/protobuf
     ports:
       - "127.0.0.1:5001:5001"

--- a/smoke-tests/docker-compose.yml
+++ b/smoke-tests/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     <<: *app_base
     environment:
       <<: *env_base
-      HONEYCOMB_API_ENDPOINT: http://collector:4318
+      HONEYCOMB_API_ENDPOINT: http://collector:4318/v1/traces
       OTEL_EXPORTER_OTLP_PROTOCOL: http/protobuf
     ports:
       - "127.0.0.1:5001:5001"

--- a/smoke-tests/smoke-sdk-http.bats
+++ b/smoke-tests/smoke-sdk-http.bats
@@ -1,0 +1,32 @@
+#!/usr/bin/env bats
+
+load test_helpers/utilities
+
+CONTAINER_NAME="app-sdk-http"
+
+setup_file() {
+	echo "# 🚧" >&3
+	docker-compose up --detach collector ${CONTAINER_NAME}
+	wait_for_ready_app ${CONTAINER_NAME}
+	curl --silent "http://localhost:5001/weatherforecast"
+	wait_for_traces
+}
+
+teardown_file() {
+    cp collector/data.json collector/data-results/data-${CONTAINER_NAME}.json
+	docker-compose stop ${CONTAINER_NAME}
+	docker-compose restart collector
+	wait_for_flush
+}
+
+# TESTS
+
+# @test "Manual instrumentation produces span with name of span" {
+# 	result=$(span_names_for 'examples')
+# 	assert_equal "$result" '"greetings"'
+# }
+
+# @test "Manual instrumentation adds custom attribute" {
+# 	result=$(span_attributes_for "examples" | jq "select(.key == \"custom_field\").value.stringValue")
+# 	assert_equal "$result" '"important value"'
+# }

--- a/smoke-tests/smoke-sdk-http.bats
+++ b/smoke-tests/smoke-sdk-http.bats
@@ -14,7 +14,7 @@ setup_file() {
 }
 
 teardown_file() {
-    cp collector/data.json collector/data-results/data-${CONTAINER_NAME}.json
+	cp collector/data.json collector/data-results/data-${CONTAINER_NAME}.json
 	docker-compose stop ${CONTAINER_NAME}
 	docker-compose restart collector
 	wait_for_flush

--- a/smoke-tests/smoke-sdk-http.bats
+++ b/smoke-tests/smoke-sdk-http.bats
@@ -21,12 +21,12 @@ teardown_file() {
 
 # TESTS
 
-# @test "Manual instrumentation produces span with name of span" {
-# 	result=$(span_names_for 'examples')
-# 	assert_equal "$result" '"greetings"'
-# }
+@test "Manual instrumentation produces span with name of span" {
+	result=$(span_names_for "aspnetcore-example")
+	assert_equal "$result" '"sleep"'
+}
 
-# @test "Manual instrumentation adds custom attribute" {
-# 	result=$(span_attributes_for "examples" | jq "select(.key == \"custom_field\").value.stringValue")
-# 	assert_equal "$result" '"important value"'
-# }
+@test "Manual instrumentation adds custom attribute" {
+	result=$(span_attributes_for "aspnetcore-example" | jq "select(.key == \"delay_ms\").value.intValue")
+	assert_equal "$result" '"100"'
+}

--- a/smoke-tests/smoke-sdk-http.bats
+++ b/smoke-tests/smoke-sdk-http.bats
@@ -3,6 +3,7 @@
 load test_helpers/utilities
 
 CONTAINER_NAME="app-sdk-http"
+OTEL_SERVICE_NAME="aspnetcore-example"
 
 setup_file() {
 	echo "# 🚧" >&3
@@ -22,11 +23,11 @@ teardown_file() {
 # TESTS
 
 @test "Manual instrumentation produces span with name of span" {
-	result=$(span_names_for "aspnetcore-example")
+	result=$(span_names_for ${OTEL_SERVICE_NAME})
 	assert_equal "$result" '"sleep"'
 }
 
 @test "Manual instrumentation adds custom attribute" {
-	result=$(span_attributes_for "aspnetcore-example" | jq "select(.key == \"delay_ms\").value.intValue")
+	result=$(span_attributes_for ${OTEL_SERVICE_NAME} | jq "select(.key == \"delay_ms\").value.intValue")
 	assert_equal "$result" '"100"'
 }

--- a/smoke-tests/test_helpers/utilities.bash
+++ b/smoke-tests/test_helpers/utilities.bash
@@ -1,0 +1,128 @@
+# UTILITY FUNCS
+
+spans_from_library_named() {
+	spans_received | jq ".scopeSpans[] | select(.scope.name == \"$1\").spans[]"
+}
+
+metrics_from_library_named() {
+	metrics_received | jq ".scopeMetrics[] | select(.scope.name == \"$1\").metrics[]"
+}
+
+spans_received() {
+	jq ".resourceSpans[]?" ./collector/data.json
+}
+
+metrics_received() {
+	jq ".resourceMetrics[]?" ./collector/data.json
+}
+
+# test span name
+span_names_for() {
+	spans_from_library_named $1 | jq '.name'
+}
+
+# test span attributes
+span_attributes_for() {
+	# $1 - library name
+
+	spans_from_library_named $1 | \
+		jq ".attributes[]"
+}
+
+# test metric name
+metric_names_for() {
+	metrics_from_library_named $1 | jq '.name'
+}
+
+# Arguments
+# $1 - retry limit (default 5); Nth retry sleeps for N seconds
+wait_for_metrics() {
+	echo -n "# ⏳ Waiting for collector to receive metrics" >&3
+	NEXT_WAIT_TIME=0
+	MAX_RETRIES=${1:-5}
+	until [ $NEXT_WAIT_TIME -eq $MAX_RETRIES ] || [ "$(metrics_received)" != "" ]
+	do
+		echo -n " ... $(( NEXT_WAIT_TIME++ ))s" >&3
+		sleep $NEXT_WAIT_TIME
+	done
+	echo "" >&3
+	[ $NEXT_WAIT_TIME -lt $MAX_RETRIES ]
+}
+
+# Arguments
+# $1 - retry limit (default 5); Nth retry sleeps for N seconds
+wait_for_data() {
+	echo -n "# ⏳ Waiting for collector to receive data" >&3
+	NEXT_WAIT_TIME=0
+	MAX_RETRIES=${1:-5}
+	until [ $NEXT_WAIT_TIME -eq $MAX_RETRIES ] || [ "$(wc -l ./collector/data.json | awk '{ print $1 }')" -ne 0 ]
+	do
+		echo -n " ... $(( NEXT_WAIT_TIME++ ))s" >&3
+		sleep $NEXT_WAIT_TIME
+	done
+	echo "" >&3
+	[ $NEXT_WAIT_TIME -lt $MAX_RETRIES ]
+}
+
+# Arguments
+# $1 - retry limit (default 5); Nth retry sleeps for N seconds
+wait_for_traces() {
+	echo -n "# ⏳ Waiting for collector to receive traces" >&3
+	NEXT_WAIT_TIME=0
+	MAX_RETRIES=${1:-5}
+	until [ $NEXT_WAIT_TIME -eq $MAX_RETRIES ] || [ "$(spans_received)" != "" ]
+	do
+		echo -n " ... $(( NEXT_WAIT_TIME++ ))s" >&3
+		sleep $NEXT_WAIT_TIME
+	done
+	echo "" >&3
+	[ $NEXT_WAIT_TIME -lt $MAX_RETRIES ]
+}
+
+wait_for_flush() {
+	echo -n "# ⏳ Waiting for collector data flush" >&3
+	NEXT_WAIT_TIME=0
+	until [ $NEXT_WAIT_TIME -eq 5 ] || [ "$(wc -l ./collector/data.json | awk '{ print $1 }')" -eq 0 ]
+	do
+		echo -n " ... $(( NEXT_WAIT_TIME++ ))s" >&3
+		sleep $NEXT_WAIT_TIME
+	done
+	echo "" >&3
+	[ $NEXT_WAIT_TIME -lt 5 ]
+}
+
+# Wait loop for one of our example Dotnet apps to be started and ready to receive traffic.
+#
+# Arguments:
+#   $1 - the name of the container/service in which the app is running
+wait_for_ready_app() {
+	CONTAINER=${1:?container name is a required parameter}
+	MAX_RETRIES=10
+	echo -n "# 🍿 Setting up ${CONTAINER}" >&3
+	NEXT_WAIT_TIME=0
+	until [ $NEXT_WAIT_TIME -eq $MAX_RETRIES ] || [[ $(docker-compose logs ${CONTAINER} | grep "Now listening on:") ]]
+	do
+		echo -n " ... $(( NEXT_WAIT_TIME++ ))s" >&3
+		sleep $NEXT_WAIT_TIME
+	done
+	echo "" >&3
+	[ $NEXT_WAIT_TIME -lt $MAX_RETRIES ]
+}
+
+# Fail and display details if the expected and actual values do not
+# equal. Details include both values.
+#
+# Lifted and then drastically simplified from bats-assert * bats-support
+assert_equal() {
+	if [[ $1 != "$2" ]]; then
+		{
+			echo
+			echo "-- 💥 values are not equal 💥 --"
+			echo "expected : $2"
+			echo "actual   : $1"
+			echo "--"
+			echo
+		} >&2 # output error to STDERR
+		return 1
+	fi
+}


### PR DESCRIPTION
## Which problem is this PR solving?
Adds smoke tests for the example `aspnetcore` example app over http/protobuf. These will eventually be used for CI smoke tests to ensure our core functionality works as expected.
- Closes #236 

## Short description of the changes
- Added `app-sdk-http` service to `smoke-tests/docker-compose.yml` that starts the example app with the traces endpoint configured to send traces over http to the collector and set the protocol to `http/protobuf`
- Added `some-tests/test_helpers/utilities.bash` which is largely the same as the [utilities in the Java distro](https://github.com/honeycombio/honeycomb-opentelemetry-java/blob/main/smoke-tests/test_helpers/utilities.bash), the only difference is the [string we're looking for to indicate that the app is ready](https://github.com/honeycombio/honeycomb-opentelemetry-dotnet/compare/purvi/http-smoke-tests?expand=1#diff-69bba216fe8849f3acb7dbb6090bcc3ff5a89b7a83c2217d2d92315663155225R103).
- Added bats tests in `smoke-tests/smoke-sdk-http.bats` that test manual instrumentation for traces

## How to test
1. Fetch this branch locally and check it out
2. `cd smoke && bats ./smoke-sdk-http.bats`

You should see two passing tests

## Out of scope
- While working on this I realized that `HONEYCOMB_API_ENDPOINT` does not append `v1/traces` by default. Is this something we want to add in? Our [distro spec](https://github.com/honeycombio/specs/blob/main/specs/otel-sdk-distro.md) doesn't mention anything about it, but our [Java distro seems to append the path](https://github.com/honeycombio/honeycomb-opentelemetry-java/pull/296/files#diff-77b6a4fb13aa4157df46051e7262c7687f5a3af8507f255c8a5eaa8f5763637cR225).
- Do we want to add any metrics or logs tests?

