### PR TITLE
Add make targets for smoke tests & set up CI smoke tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   windows: circleci/windows@5.0.0
+  bats: circleci/bats@1.0.0
 
 commands:
   setup:
@@ -68,6 +69,12 @@ jobs:
       - checkout
       - attach_workspace:
           at: ./
+      - bats/install
+      - run:
+          name: What's the BATS?
+          command: |
+            which bats
+            bats --version
       - run:
           name: Smoke Test
           command: make smoke

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,12 @@ jobs:
       - run:
           name: Smoke Test
           command: make smoke
+      - store_test_results:
+          path: ./smoke-tests/
+      - store_artifacts:
+          path: ./smoke-tests/report.xml
+      - store_artifacts:
+          path: ./smoke-tests/collector/data-results
       - run:
           name: Extinguish the flames
           command: make unsmoke

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
       - attach_workspace:
           at: ./
       - run:
-          name: Smoke Test Placeholder
+          name: Smoke Test
           command: make smoke
       - run:
           name: Extinguish the flames

--- a/Makefile
+++ b/Makefile
@@ -14,16 +14,23 @@ clean:
 	rm -rf ./test/Honeycomb.OpenTelemetry.Tests/obj/*
 	rm -rf ./src/Honeycomb.OpenTelemetry/bin/*
 	rm -rf ./src/Honeycomb.OpenTelemetry/obj/*
+	rm -rf ./smoke-tests/report.*
+	rm -rf ./smoke-tests/collector/data.json
+	rm -rf ./smoke-tests/collector/data-results/*.json
 	dotnet clean
 
+smoke-tests/collector/data.json:
+	@echo ""
+	@echo "+++ Zhuzhing smoke test's Collector data.json"
+	@touch $@ && chmod o+w $@
 
-smoke-sdk-grpc:
+smoke-sdk-grpc: smoke-tests/collector/data.json
 	@echo ""
 	@echo "+++ Running gRPC smoke tests."
 	@echo ""
 	cd smoke-tests && bats ./smoke-sdk-grpc.bats --report-formatter junit --output ./
 
-smoke-sdk-http:
+smoke-sdk-http: smoke-tests/collector/data.json
 	@echo ""
 	@echo "+++ Running HTTP smoke tests."
 	@echo ""

--- a/Makefile
+++ b/Makefile
@@ -43,12 +43,13 @@ smoke-sdk: smoke-sdk-grpc smoke-sdk-http
 
 smoke: smoke-sdk
 
-unsmoke: clean-smoke-tests
+unsmoke:
 	@echo ""
 	@echo "+++ Spinning down the smokers."
 	@echo ""
 	cd smoke-tests && docker-compose down --volumes
 
+## use this for local testing
 resmoke: unsmoke smoke
 
 ${NUGET_PACKAGES_LOCAL}:

--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,22 @@ clean:
 	rm -rf ./src/Honeycomb.OpenTelemetry/obj/*
 	dotnet clean
 
-smoke:
+
+smoke-sdk-grpc:
 	@echo ""
-	@echo "+++ Placeholder for Smoking all the tests."
+	@echo "+++ Running gRPC smoke tests."
 	@echo ""
-	cd smoke-tests && docker-compose up -d --build collector app-sdk-http && docker-compose down --volumes
+	cd smoke-tests && bats ./smoke-sdk-grpc.bats --report-formatter junit --output ./
+
+smoke-sdk-http:
+	@echo ""
+	@echo "+++ Running HTTP smoke tests."
+	@echo ""
+	cd smoke-tests && bats ./smoke-sdk-http.bats --report-formatter junit --output ./
+
+smoke-sdk: smoke-sdk-grpc smoke-sdk-http
+
+smoke: smoke-sdk
 
 unsmoke:
 	@echo ""
@@ -40,4 +51,4 @@ publish_local: local_nuget_source_registered
 	@echo "Publishing nuget package(s) to: ${NUGET_PACKAGES_LOCAL}\n"
 	@dotnet pack -c release -o ${NUGET_PACKAGES_LOCAL} -p:signed=false
 
-.PHONY: build test clean smoke unsmoke resmoke local_nuget_source_registered publish_local
+.PHONY: build test clean smoke unsmoke resmoke local_nuget_source_registered publish_local smoke-sdk-grpc smoke-sdk

--- a/Makefile
+++ b/Makefile
@@ -7,17 +7,20 @@ build:
 test: build
 	dotnet test --no-build
 
-clean:
+clean-smoke-tests:
+	rm -rf ./smoke-tests/collector/data.json
+	rm -rf ./smoke-tests/collector/data-results/*.json
+	rm -rf ./smoke-tests/report.*
+
+clean: clean-smoke-tests
 	rm -rf ./examples/aspnetcore/bin/*
 	rm -rf ./examples/aspnetcore/obj/*
 	rm -rf ./test/Honeycomb.OpenTelemetry.Tests/bin/*
 	rm -rf ./test/Honeycomb.OpenTelemetry.Tests/obj/*
 	rm -rf ./src/Honeycomb.OpenTelemetry/bin/*
 	rm -rf ./src/Honeycomb.OpenTelemetry/obj/*
-	rm -rf ./smoke-tests/report.*
-	rm -rf ./smoke-tests/collector/data.json
-	rm -rf ./smoke-tests/collector/data-results/*.json
 	dotnet clean
+
 
 smoke-tests/collector/data.json:
 	@echo ""
@@ -40,7 +43,7 @@ smoke-sdk: smoke-sdk-grpc smoke-sdk-http
 
 smoke: smoke-sdk
 
-unsmoke:
+unsmoke: clean-smoke-tests
 	@echo ""
 	@echo "+++ Spinning down the smokers."
 	@echo ""

--- a/Makefile
+++ b/Makefile
@@ -58,4 +58,4 @@ publish_local: local_nuget_source_registered
 	@echo "Publishing nuget package(s) to: ${NUGET_PACKAGES_LOCAL}\n"
 	@dotnet pack -c release -o ${NUGET_PACKAGES_LOCAL} -p:signed=false
 
-.PHONY: build test clean smoke unsmoke resmoke local_nuget_source_registered publish_local smoke-sdk-grpc smoke-sdk
+.PHONY: build test clean smoke unsmoke resmoke local_nuget_source_registered publish_local smoke-sdk-grpc smoke-sdk-http smoke-sdk

--- a/Makefile
+++ b/Makefile
@@ -62,4 +62,4 @@ publish_local: local_nuget_source_registered
 	@echo "Publishing nuget package(s) to: ${NUGET_PACKAGES_LOCAL}\n"
 	@dotnet pack -c release -o ${NUGET_PACKAGES_LOCAL} -p:signed=false
 
-.PHONY: build test clean smoke unsmoke resmoke local_nuget_source_registered publish_local smoke-sdk-grpc smoke-sdk-http smoke-sdk
+.PHONY: build test clean smoke unsmoke resmoke local_nuget_source_registered publish_local smoke-sdk-grpc smoke-sdk-http smoke-sdk clean-smoke-tests


### PR DESCRIPTION
## Which problem is this PR solving?
Adds make targets for smoke tests and run them in CI.
- Closes #234 
- Closes #235 

## Short description of the changes
### Makefile Changes
- `smoke-tests/collector/data.json` makes sure there is always a `data.json` file in the collector folder so that tests can run reliably
- `smoke-sdk-grpc` runs bats tests for smoke tests over gRPC
- `smoke-sdk-http` runs bats tests for smoke tests over http/protobuf
- `smoke-sdk` runs bats tests for all sdk tests
- `smoke` runs all bats smoke tests
- `unsmoke` tears down setup for smoke tests
- `resmoke` tears down and then runs smoke tests

### CI Changes
- added bats 1.0 orb and installed 1.0 bats during smoke-tests job
- stored test results so that CI [test tab is populated correctly](https://app.circleci.com/pipelines/github/honeycombio/honeycomb-opentelemetry-dotnet/1016/workflows/35275038-739c-4781-b7f8-a600a3f2e571/jobs/1543/tests)
- stored artifacts for test results and JSON files with traces

## How to test
### Local Makefile
1. Fetch and checkout this branch
2. Test the new commands by running `make <command>`
3. Locally, it is important to `unsmoke` after running a set of tests, you can get into a weird state if you run `clean` without `unsmoke`.

### CI
- [x] [Test output shows up in the console ](https://app.circleci.com/pipelines/github/honeycombio/honeycomb-opentelemetry-dotnet/1016/workflows/35275038-739c-4781-b7f8-a600a3f2e571/jobs/1543/steps?invite=true#step-105-6)
- [x] [Test tab is populated correctly](https://app.circleci.com/pipelines/github/honeycombio/honeycomb-opentelemetry-dotnet/1016/workflows/35275038-739c-4781-b7f8-a600a3f2e571/jobs/1543/tests)
- [x] [Artifacts are uploaded](https://app.circleci.com/pipelines/github/honeycombio/honeycomb-opentelemetry-dotnet/1016/workflows/35275038-739c-4781-b7f8-a600a3f2e571/jobs/1543/artifacts)
- [x] [Tests are passing](https://app.circleci.com/pipelines/github/honeycombio/honeycomb-opentelemetry-dotnet/1016/workflows/35275038-739c-4781-b7f8-a600a3f2e571/jobs/1543)




