### PR TITLE
ENABLE_LOCAL_VISUALIZATIONS -> HONEYCOMB_ENABLE_LOCAL_VISUALIZATIONS

### DIFF
--- a/src/Honeycomb.OpenTelemetry/EnvironmentOptions.cs
+++ b/src/Honeycomb.OpenTelemetry/EnvironmentOptions.cs
@@ -17,7 +17,7 @@ namespace Honeycomb.OpenTelemetry
         private const string SampleRateKey = "HONEYCOMB_SAMPLE_RATE";
         private const string ServiceNameKey = "OTEL_SERVICE_NAME";
         private const string ServiceVersionKey = "SERVICE_VERSION";
-        private const string EnableLocalVisualizationsKey = "ENABLE_LOCAL_VISUALIZATIONS";
+        private const string EnableLocalVisualizationsKey = "HONEYCOMB_ENABLE_LOCAL_VISUALIZATIONS";
         private const string DebugKey = "DEBUG";
         private const uint DefaultSampleRate = 1;
         private const string DefaultApiEndpoint = "https://api.honeycomb.io:443";

--- a/test/Honeycomb.OpenTelemetry.Tests/EnvironmentOptionsTests.cs
+++ b/test/Honeycomb.OpenTelemetry.Tests/EnvironmentOptionsTests.cs
@@ -22,7 +22,7 @@ namespace Honeycomb.OpenTelemetry
                 {"HONEYCOMB_SAMPLE_RATE", "10"},
                 {"OTEL_SERVICE_NAME", "my-service-name"},
                 {"SERVICE_VERSION", "my-service-version"},
-                {"ENABLE_LOCAL_VISUALIZATIONS", "true" },
+                {"HONEYCOMB_ENABLE_LOCAL_VISUALIZATIONS", "true" },
                 {"DEBUG", "true"}
             };
             var options = new EnvironmentOptions(values);
@@ -77,7 +77,7 @@ namespace Honeycomb.OpenTelemetry
                 {"HONEYCOMB_SAMPLE_RATE", "10"},
                 {"OTEL_SERVICE_NAME", "my-env-service-name"},
                 {"SERVICE_VERSION", "my-env-service-version"},
-                {"ENABLE_LOCAL_VISUALIZATIONS", "true" },
+                {"HONEYCOMB_ENABLE_LOCAL_VISUALIZATIONS", "true" },
                 {"DEBUG", "true"}
             };
             var options = new EnvironmentOptions(values);


### PR DESCRIPTION
Why the name change?

* This is the name in the go distro, so we'd have to change one or the other
* This aligns with the rest of the honeycomb-specific environment variables, where `HONEYCOMB` comes first. I think we should probably do that