### PR TITLE
Move extensions into owning class namespace & rename add instrumentations ext method

### DIFF
--- a/src/Honeycomb.OpenTelemetry.AutoInstrumentations/TracerProviderBuilderExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry.AutoInstrumentations/TracerProviderBuilderExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using Npgsql;
-using OpenTelemetry.Trace;
 
-namespace Honeycomb.OpenTelemetry.AutoInstrumentations
+namespace OpenTelemetry.Trace
 {
     /// <summary>
     /// Extension methods to add instrumentation support for many common instrumentation packages.

--- a/src/Honeycomb.OpenTelemetry.AutoInstrumentations/TracerProviderBuilderExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry.AutoInstrumentations/TracerProviderBuilderExtensions.cs
@@ -12,7 +12,7 @@ namespace OpenTelemetry.Trace
         /// </summary>
         /// <param name="builder"><see cref="TracerProviderBuilder"/> being configured.</param>
         /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
-        public static TracerProviderBuilder AddAllInstrumentation(this TracerProviderBuilder builder)
+        public static TracerProviderBuilder AddAutoInstrumentations(this TracerProviderBuilder builder)
         {
             return
                 builder

--- a/src/Honeycomb.OpenTelemetry/MeterProviderBuilderExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry/MeterProviderBuilderExtensions.cs
@@ -1,8 +1,8 @@
-using OpenTelemetry.Metrics;
+using Honeycomb.OpenTelemetry;
 using OpenTelemetry.Resources;
 using System;
 
-namespace Honeycomb.OpenTelemetry
+namespace OpenTelemetry.Metrics
 {
     /// <summary>
     /// Extension methods to configure <see cref="MeterProviderBuilder"/> to send metrics telemetry data to Honeycomb.

--- a/src/Honeycomb.OpenTelemetry/ResourceBuilderExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry/ResourceBuilderExtensions.cs
@@ -1,10 +1,9 @@
-using OpenTelemetry.Resources;
 using System;
 using System.Runtime.InteropServices;
 using System.Collections.Generic;
 using System.Reflection;
 
-namespace Honeycomb.OpenTelemetry
+namespace OpenTelemetry.Resources
 {
     /// <summary>
     /// Extension methods to configure <see cref="ResourceBuilder"/> with Honeycomb distro attributes.
@@ -111,7 +110,7 @@ namespace Honeycomb.OpenTelemetry
 
         private static string GetFileVersion()
         {
-            var version = typeof(ResourceBuilderExtensions)
+            var version = typeof(Honeycomb.OpenTelemetry.HoneycombOptions)
                 .Assembly
                 .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
                 .InformationalVersion;
@@ -120,7 +119,7 @@ namespace Honeycomb.OpenTelemetry
             // the form `{version_prefix}{version_suffix}+{commit_hash}`.
             // We should trim the hash if present to just leave the version prefix and suffix
             var i = version.IndexOf("+");
-            return i > 0 
+            return i > 0
                 ? version.Substring(0, i)
                 : version;
         }

--- a/src/Honeycomb.OpenTelemetry/TracerProviderBuilderExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry/TracerProviderBuilderExtensions.cs
@@ -1,14 +1,13 @@
+using Honeycomb.OpenTelemetry;
 using Microsoft.Extensions.Configuration;
-using OpenTelemetry;
 using OpenTelemetry.Resources;
-using OpenTelemetry.Trace;
 using System;
 
 #if NET462
 using System.Collections.Generic;
 #endif
 
-namespace Honeycomb.OpenTelemetry
+namespace OpenTelemetry.Trace
 {
     /// <summary>
     /// Extension methods to configure <see cref="TracerProviderBuilder"/> to send telemetry data to Honeycomb.


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
When providing extensions for classes in other libraries, the expectation is to use the same namespace as this doesn't require consumers to add extra imports.

This PR updates all extension classes to use the same namespace as the class that's being extended. eg TracerProviderBuilder is now in OpenTelemetry.Trace.

It also renames `AddAllInstrumentation` to `AddAutoInstrumentations` which is a clearer function name and can't be insinuated that we it will add _all_ possible instrumentation packages instead of ones we've selected.

- Closes https://github.com/honeycombio/honeycomb-opentelemetry-dotnet/issues/274

## Short description of the changes
- Move extensions classes into the same namespace as the class that's being extended.
- Rename `AddAllInstrumentation` to `AddAutoInstrumentations`