### PR TITLE
Add ConfigurationManager extension methods

### DIFF
--- a/examples/aspnetcore-redis/Program.cs
+++ b/examples/aspnetcore-redis/Program.cs
@@ -1,4 +1,3 @@
-using Honeycomb.OpenTelemetry;
 using OpenTelemetry.Trace;
 using StackExchange.Redis;
 
@@ -14,9 +13,7 @@ var redis = ConnectionMultiplexer.Connect(
 );
 builder.Services.AddSingleton<IConnectionMultiplexer>(redis);
 
-var honeycombOptions =
-    builder.Configuration.GetSection(HoneycombOptions.ConfigSectionName)
-        .Get<HoneycombOptions>();
+var honeycombOptions = builder.Configuration.GetHoneycombOptions();
 
 builder.Services.AddOpenTelemetryTracing(otelBuilder =>
     otelBuilder

--- a/examples/aspnetcore/Program.cs
+++ b/examples/aspnetcore/Program.cs
@@ -1,17 +1,14 @@
-using Honeycomb.OpenTelemetry;
 using OpenTelemetry.Trace;
 using System.Diagnostics.Metrics;
 
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddControllers();
 
-var honeycombOptions =
-    builder.Configuration.GetSection(HoneycombOptions.ConfigSectionName)
-        .Get<HoneycombOptions>();
+var honeycombOptions = builder.Configuration.GetHoneycombOptions();
 
 builder.Services.AddOpenTelemetryTracing(otelBuilder =>
     otelBuilder
-        .AddHoneycomb(builder.Configuration)
+        .AddHoneycomb(honeycombOptions)
         .AddAspNetCoreInstrumentationWithBaggage()
 );
 

--- a/src/Honeycomb.OpenTelemetry/WebApplicationBuilderExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry/WebApplicationBuilderExtensions.cs
@@ -1,0 +1,20 @@
+using Honeycomb.OpenTelemetry;
+
+namespace Microsoft.Extensions.Configuration
+{
+    /// <summary>
+    /// Extension methods for <see cref="ConfigurationManager"/> to help configure Honeycomb with OpenTelemetry.
+    /// </summary>
+    public static class ConfigurationManagerExtensions
+    {
+        /// <summary>
+        /// Attempts to retrieve an instance of <see cref="HoneycombOptions"/> used to configre the OpenTelemetry SDK.
+        /// </summary>
+        public static HoneycombOptions GetHoneycombOptions(this ConfigurationManager builder)
+        {
+            return builder
+                .GetSection(HoneycombOptions.ConfigSectionName)
+                .Get<HoneycombOptions>();;
+        }
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Adds extension methods for ConfigurationBuilder to help making getting options from appsettings.json.

## Short description of the changes
- Adds ConfigurationBuilder extension method
- Update aspnetcore examples to use new ext method

