### PR TITLE
Append /v1/metrics to endpoint path if the protocol is HTTP

### DIFF
--- a/smoke-tests/collector/otel-collector-config.yaml
+++ b/smoke-tests/collector/otel-collector-config.yaml
@@ -22,8 +22,7 @@ service:
     metrics:
       receivers: [otlp]
       processors: [batch]
-      # exporters: [file, logging]
-      exporters: [logging]
+      exporters: [file, logging]
     logs:
       receivers: [otlp]
       processors: [batch]

--- a/smoke-tests/docker-compose.yml
+++ b/smoke-tests/docker-compose.yml
@@ -5,7 +5,7 @@ x-env-base: &env_base
   HONEYCOMB_API_KEY: bogus_key
   HONEYCOMB_DATASET: bogus_dataset
   HONEYCOMB_METRICS_DATASET: bogus_dataset
-  OTEL_METRIC_EXPORT_INTERVAL: 1000
+  OTEL_METRIC_EXPORT_INTERVAL: 100
   OTEL_SERVICE_NAME: "aspnetcore-example"
   DEBUG: "true"
 
@@ -37,6 +37,7 @@ services:
     environment:
       <<: *env_base
       HONEYCOMB_API_ENDPOINT: http://collector:4318
+      HONEYCOMB_METRICS_ENDPOINT: http://collector:4318/v1/metrics
       OTEL_EXPORTER_OTLP_PROTOCOL: http/protobuf
     ports:
       - "127.0.0.1:5001:5001"

--- a/smoke-tests/docker-compose.yml
+++ b/smoke-tests/docker-compose.yml
@@ -37,7 +37,6 @@ services:
     environment:
       <<: *env_base
       HONEYCOMB_API_ENDPOINT: http://collector:4318
-      HONEYCOMB_METRICS_ENDPOINT: http://collector:4318/v1/metrics
       OTEL_EXPORTER_OTLP_PROTOCOL: http/protobuf
     ports:
       - "127.0.0.1:5001:5001"

--- a/smoke-tests/smoke-sdk-grpc.bats
+++ b/smoke-tests/smoke-sdk-grpc.bats
@@ -4,6 +4,7 @@ load test_helpers/utilities
 
 CONTAINER_NAME="app-sdk-grpc"
 OTEL_SERVICE_NAME="aspnetcore-example"
+METRICS_DATASET="bogus_dataset"
 
 setup_file() {
 	echo "# 🚧" >&3
@@ -11,6 +12,7 @@ setup_file() {
 	wait_for_ready_app ${CONTAINER_NAME}
 	curl --silent "http://localhost:5001/weatherforecast"
 	wait_for_traces
+    wait_for_metrics 15
 }
 
 teardown_file() {
@@ -30,4 +32,9 @@ teardown_file() {
 @test "Manual instrumentation adds custom attribute" {
 	result=$(span_attributes_for ${OTEL_SERVICE_NAME} | jq "select(.key == \"delay_ms\").value.intValue")
 	assert_equal "$result" '"100"'
+}
+
+@test "Manual instrumentation produces metrics" {
+    result=$(metric_names_for ${METRICS_DATASET})
+    assert_equal "$result" '"sheep"'
 }

--- a/smoke-tests/smoke-sdk-http.bats
+++ b/smoke-tests/smoke-sdk-http.bats
@@ -4,6 +4,7 @@ load test_helpers/utilities
 
 CONTAINER_NAME="app-sdk-http"
 OTEL_SERVICE_NAME="aspnetcore-example"
+METRICS_DATASET="bogus_dataset"
 
 setup_file() {
 	echo "# 🚧" >&3
@@ -11,6 +12,7 @@ setup_file() {
 	wait_for_ready_app ${CONTAINER_NAME}
 	curl --silent "http://localhost:5001/weatherforecast"
 	wait_for_traces
+    wait_for_metrics 15
 }
 
 teardown_file() {
@@ -30,4 +32,9 @@ teardown_file() {
 @test "Manual instrumentation adds custom attribute" {
 	result=$(span_attributes_for ${OTEL_SERVICE_NAME} | jq "select(.key == \"delay_ms\").value.intValue")
 	assert_equal "$result" '"100"'
+}
+
+@test "Manual instrumentation produces metrics" {
+    result=$(metric_names_for ${METRICS_DATASET})
+    assert_equal "$result" '"sheep"'
 }

--- a/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
+++ b/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
@@ -17,7 +17,7 @@ namespace Honeycomb.OpenTelemetry
         private const string OtelExporterOtlpProtocolHttpJson = "http/json";
         private const string OtelExporterOtlpProtocolGrpc = "grpc";
         private const string OtelExporterHttpTracesPath = "/v1/traces";
-
+        private const string OtelExporterHttpMetricsPath = "/v1/traces";
         private bool isHttp = false;
 
         /// <summary>
@@ -230,7 +230,7 @@ namespace Honeycomb.OpenTelemetry
         }
 
         /// <summary>
-        /// Computes the final traces endpoint.
+        /// Gets the <see cref="TracesEndpoint" /> or falls back to the generic <see cref="Endpoint" />.
         /// </summary>
         internal string GetTracesEndpoint()
         {
@@ -257,7 +257,12 @@ namespace Honeycomb.OpenTelemetry
         /// </summary>
         internal string GetMetricsEndpoint()
         {
-            return new UriBuilder(MetricsEndpoint ?? Endpoint).ToString();
+            var endpoint = new UriBuilder(Endpoint);
+            if (isHttp && (string.IsNullOrWhiteSpace(endpoint.Path) || endpoint.Path == "/"))
+            {
+                endpoint.Path = OtelExporterHttpMetricsPath;
+            }
+            return MetricsEndpoint ?? endpoint.ToString();
         }
 
         /// <summary>

--- a/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
+++ b/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
@@ -17,7 +17,7 @@ namespace Honeycomb.OpenTelemetry
         private const string OtelExporterOtlpProtocolHttpJson = "http/json";
         private const string OtelExporterOtlpProtocolGrpc = "grpc";
         private const string OtelExporterHttpTracesPath = "/v1/traces";
-        private const string OtelExporterHttpMetricsPath = "/v1/traces";
+        private const string OtelExporterHttpMetricsPath = "/v1/metrics";
         private bool isHttp = false;
 
         /// <summary>

--- a/test/Honeycomb.OpenTelemetry.Tests/HoneycombOptionsTests.cs
+++ b/test/Honeycomb.OpenTelemetry.Tests/HoneycombOptionsTests.cs
@@ -430,6 +430,99 @@ namespace Honeycomb.OpenTelemetry.Tests
             Assert.DoesNotContain("/v1/traces", options.GetTracesEndpoint());
         }
 
+        [Theory]
+        [InlineData("http/protobuf", "http://collector:4318", null)]
+        [InlineData("http/json", "http://collector:4318", null)]
+        [InlineData("http/protobuf", null, "http://collector:4318")]
+        [InlineData("http/json", null, "http://collector:4318")]
+        [InlineData("http/protobuf", "http://collector:4318", "http://collector:4318")]
+        [InlineData("http/json", "http://collector:4318", "http://collector:4318")]
+        public void AppendsMetricsPathIfProtocolIsHttp(string protocol, string configEndpoint, string envVarEndpoint)
+        {
+            var options = new HoneycombOptions
+            {
+                Endpoint = configEndpoint
+            };
+            var values = new Dictionary<string, string>
+            {
+                {"OTEL_EXPORTER_OTLP_PROTOCOL", protocol},
+                {"HONEYCOMB_API_ENDPOINT", envVarEndpoint},
+            };
+
+            options.ApplyEnvironmentOptions(new EnvironmentOptions(values));
+            Assert.Equal($"{options.Endpoint}/v1/metrics", options.GetMetricsEndpoint());
+        }
+
+        [Theory]
+        [InlineData("http://collector:4317", null)]
+        [InlineData(null, "http://collector:4317")]
+        [InlineData("http://collector:4317", "http://collector:4317")]
+        public void DoesNotAppendMetricsPathIfProtocolIsGrpc(string configEndpoint, string envVarEndpoint)
+        {
+            var options = new HoneycombOptions
+            {
+                Endpoint = configEndpoint
+            };
+            var values = new Dictionary<string, string>
+            {
+                {"OTEL_EXPORTER_OTLP_PROTOCOL", "grpc"},
+                {"HONEYCOMB_API_ENDPOINT", envVarEndpoint},
+            };
+
+            options.ApplyEnvironmentOptions(new EnvironmentOptions(values));
+            Assert.Equal("http://collector:4317/", options.GetMetricsEndpoint());
+            Assert.DoesNotContain("/v1/metrics", options.GetMetricsEndpoint());
+        }
+
+        [Theory]
+        [InlineData("http/protobuf", "http://collector:4318", null)]
+        [InlineData("http/json", "http://collector:4318", null)]
+        [InlineData("http/protobuf", null, "http://collector:4318")]
+        [InlineData("http/json", null, "http://collector:4318")]
+        [InlineData("http/protobuf", "http://collector:4318", "http://collector:4318")]
+        [InlineData("http/json", "http://collector:4318", "http://collector:4318")]
+        public void DoesNotAppendMetricsPathToMetricsEndpoints(string protocol, string configEndpoint, string envVarEndpoint)
+        {
+            var options = new HoneycombOptions
+            {
+                MetricsEndpoint = configEndpoint
+            };
+            var values = new Dictionary<string, string>
+            {
+                {"OTEL_EXPORTER_OTLP_PROTOCOL", protocol},
+                {"HONEYCOMB_METRICS_ENDPOINT", envVarEndpoint},
+
+            };
+
+            options.ApplyEnvironmentOptions(new EnvironmentOptions(values));
+            Assert.Equal("http://collector:4318", options.GetMetricsEndpoint());
+            Assert.DoesNotContain("/v1/metrics", options.GetMetricsEndpoint());
+        }
+
+        [Theory]
+        [InlineData("http/protobuf", "http://collector:4318/my-special-path", null)]
+        [InlineData("http/json", "http://collector:4318/my-special-path", null)]
+        [InlineData("http/protobuf", null, "http://collector:4318/my-special-path")]
+        [InlineData("http/json", null, "http://collector:4318/my-special-path")]
+        [InlineData("http/protobuf", "http://collector:4318/my-special-path", "http://collector:4318/my-special-path")]
+        [InlineData("http/json", "http://collector:4318/my-special-path", "http://collector:4318/my-special-path")]
+        public void DoesNotAppendMetricsPathToGenericEndpointIfPathSpecified(string protocol, string configEndpoint, string envVarEndpoint)
+        {
+            var options = new HoneycombOptions
+            {
+                Endpoint = configEndpoint
+            };
+            var values = new Dictionary<string, string>
+            {
+                {"OTEL_EXPORTER_OTLP_PROTOCOL", protocol},
+                {"HONEYCOMB_API_ENDPOINT", envVarEndpoint},
+            };
+
+            options.ApplyEnvironmentOptions(new EnvironmentOptions(values));
+            Assert.Equal("http://collector:4318/my-special-path", options.GetMetricsEndpoint());
+            Assert.DoesNotContain("/v1/metrics", options.GetMetricsEndpoint());
+        }
+
         [Fact]
         public void Legacy_key_length()
         {

--- a/test/Honeycomb.OpenTelemetry.Tests/HoneycombOptionsTests.cs
+++ b/test/Honeycomb.OpenTelemetry.Tests/HoneycombOptionsTests.cs
@@ -198,7 +198,7 @@ namespace Honeycomb.OpenTelemetry.Tests
                 MetricsEndpoint = "http://collector:4318",
                 MetricsApiKey = "my-api-key",
             };
-            Assert.Equal("http://collector:4318/", options.GetMetricsEndpoint());
+            Assert.Equal("http://collector:4318", options.GetMetricsEndpoint());
             Assert.Equal("my-api-key", options.GetMetricsApiKey());
         }
 

--- a/test/Honeycomb.OpenTelemetry.Tests/HoneycombOptionsTests.cs
+++ b/test/Honeycomb.OpenTelemetry.Tests/HoneycombOptionsTests.cs
@@ -337,48 +337,43 @@ namespace Honeycomb.OpenTelemetry.Tests
             Assert.Equal("my-metrics-api-key-env-var", options.GetMetricsApiKey());
         }
 
-        [Fact]
-        public void AppendsTracesPathIfProtocolIsHttpProtobuf_Config()
+        [Theory]
+        [InlineData("http/protobuf", "http://collector:4318", null)]
+        [InlineData("http/json", "http://collector:4318", null)]
+        [InlineData("http/protobuf", null, "http://collector:4318")]
+        [InlineData("http/json", null, "http://collector:4318")]
+        [InlineData("http/protobuf", "http://collector:4318", "http://collector:4318")]
+        [InlineData("http/json", "http://collector:4318", "http://collector:4318")]
+        public void AppendsTracesPathIfProtocolIsHttp(string protocol, string configEndpoint, string envVarEndpoint)
         {
             var options = new HoneycombOptions
             {
-                Endpoint = "http://collector:4318/"
+                Endpoint = configEndpoint
             };
             var values = new Dictionary<string, string>
             {
-                {"OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf"},
+                {"OTEL_EXPORTER_OTLP_PROTOCOL", protocol},
+                {"HONEYCOMB_API_ENDPOINT", envVarEndpoint},
             };
 
             options.ApplyEnvironmentOptions(new EnvironmentOptions(values));
-            Assert.Equal("http://collector:4318/v1/traces", options.GetTracesEndpoint());
+            Assert.Equal($"{options.Endpoint}/v1/traces", options.GetTracesEndpoint());
         }
 
-        [Fact]
-        public void AppendsTracesPathIfProtocolIsHttpJson_Config()
+        [Theory]
+        [InlineData("http://collector:4317", null)]
+        [InlineData(null, "http://collector:4317")]
+        [InlineData("http://collector:4317", "http://collector:4317")]
+        public void DoesNotAppendTracesPathIfProtocolIsGrpc(string configEndpoint, string envVarEndpoint)
         {
             var options = new HoneycombOptions
             {
-                Endpoint = "http://collector:4318/"
-            };
-            var values = new Dictionary<string, string>
-            {
-                {"OTEL_EXPORTER_OTLP_PROTOCOL", "http/json"},
-            };
-
-            options.ApplyEnvironmentOptions(new EnvironmentOptions(values));
-            Assert.Equal("http://collector:4318/v1/traces", options.GetTracesEndpoint());
-        }
-
-        [Fact]
-        public void DoesNotAppendTracesPathIfProtocolIsGrpc_Config()
-        {
-            var options = new HoneycombOptions
-            {
-                Endpoint = "http://collector:4317/"
+                Endpoint = configEndpoint
             };
             var values = new Dictionary<string, string>
             {
                 {"OTEL_EXPORTER_OTLP_PROTOCOL", "grpc"},
+                {"HONEYCOMB_API_ENDPOINT", envVarEndpoint},
             };
 
             options.ApplyEnvironmentOptions(new EnvironmentOptions(values));
@@ -386,108 +381,53 @@ namespace Honeycomb.OpenTelemetry.Tests
             Assert.DoesNotContain("/v1/traces", options.GetTracesEndpoint());
         }
 
-        [Fact]
-        public void AppendsTracesPathIfProtocolIsHttpProtobuf_EnvVars()
+        [Theory]
+        [InlineData("http/protobuf", "http://collector:4318", null)]
+        [InlineData("http/json", "http://collector:4318", null)]
+        [InlineData("http/protobuf", null, "http://collector:4318")]
+        [InlineData("http/json", null, "http://collector:4318")]
+        [InlineData("http/protobuf", "http://collector:4318", "http://collector:4318")]
+        [InlineData("http/json", "http://collector:4318", "http://collector:4318")]
+        public void DoesNotAppendTracesPathToTracesEndpoints(string protocol, string configEndpoint, string envVarEndpoint)
         {
-            var options = new HoneycombOptions { };
+            var options = new HoneycombOptions
+            {
+                TracesEndpoint = configEndpoint
+            };
             var values = new Dictionary<string, string>
             {
-                {"OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf"},
-                {"HONEYCOMB_API_ENDPOINT", "http://collector:4318/"}
+                {"OTEL_EXPORTER_OTLP_PROTOCOL", protocol},
+                {"HONEYCOMB_TRACES_ENDPOINT", envVarEndpoint},
+
             };
 
             options.ApplyEnvironmentOptions(new EnvironmentOptions(values));
-            Assert.Equal("http://collector:4318/v1/traces", options.GetTracesEndpoint());
-        }
-
-        [Fact]
-        public void AppendsTracesPathIfProtocolIsHttpJson_EnvVars()
-        {
-            var options = new HoneycombOptions { };
-            var values = new Dictionary<string, string>
-            {
-                {"OTEL_EXPORTER_OTLP_PROTOCOL", "http/json"},
-                {"HONEYCOMB_API_ENDPOINT", "http://collector:4318/"}
-            };
-
-            options.ApplyEnvironmentOptions(new EnvironmentOptions(values));
-            Assert.Equal("http://collector:4318/v1/traces", options.GetTracesEndpoint());
-        }
-
-        [Fact]
-        public void DoesNotAppendTracesPathIfProtocolIsGrpc_EnvVars()
-        {
-            var options = new HoneycombOptions { };
-            var values = new Dictionary<string, string>
-            {
-                {"OTEL_EXPORTER_OTLP_PROTOCOL", "grpc"},
-                {"HONEYCOMB_API_ENDPOINT", "http://collector:4317/"}
-            };
-
-            options.ApplyEnvironmentOptions(new EnvironmentOptions(values));
-            Assert.Equal("http://collector:4317/", options.GetTracesEndpoint());
+            Assert.Equal("http://collector:4318", options.GetTracesEndpoint());
             Assert.DoesNotContain("/v1/traces", options.GetTracesEndpoint());
         }
 
-        [Fact]
-        public void DoesNotAppendTracesPathToTracesEndpoint_Config()
+        [Theory]
+        [InlineData("http/protobuf", "http://collector:4318/my-special-path", null)]
+        [InlineData("http/json", "http://collector:4318/my-special-path", null)]
+        [InlineData("http/protobuf", null, "http://collector:4318/my-special-path")]
+        [InlineData("http/json", null, "http://collector:4318/my-special-path")]
+        [InlineData("http/protobuf", "http://collector:4318/my-special-path", "http://collector:4318/my-special-path")]
+        [InlineData("http/json", "http://collector:4318/my-special-path", "http://collector:4318/my-special-path")]
+        public void DoesNotAppendTracesPathToGenericEndpointIfPathSpecified(string protocol, string configEndpoint, string envVarEndpoint)
         {
             var options = new HoneycombOptions
             {
-                TracesEndpoint = "http://collector:4318/"
+                Endpoint = configEndpoint
             };
             var values = new Dictionary<string, string>
             {
-                {"OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf"},
-            };
-
-            options.ApplyEnvironmentOptions(new EnvironmentOptions(values));
-            Assert.Equal("http://collector:4318/", options.GetTracesEndpoint());
-        }
-
-        [Fact]
-        public void DoesNotAppendTracesPathToTracesEndpoint_EnvVars()
-        {
-            var options = new HoneycombOptions { };
-            var values = new Dictionary<string, string>
-            {
-                {"OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf"},
-                {"HONEYCOMB_TRACES_ENDPOINT", "http://collector:4318/"}
-            };
-
-            options.ApplyEnvironmentOptions(new EnvironmentOptions(values));
-            Assert.Equal("http://collector:4318/", options.GetTracesEndpoint());
-
-        }
-
-        [Fact]
-        public void DoesNotAppendTracesPathToGenericEndpointIfPathSpecified_Config()
-        {
-            var options = new HoneycombOptions
-            {
-                Endpoint = "http://collector:4318/my-special-path"
-            };
-            var values = new Dictionary<string, string>
-            {
-                {"OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf"},
+                {"OTEL_EXPORTER_OTLP_PROTOCOL", protocol},
+                {"HONEYCOMB_API_ENDPOINT", envVarEndpoint},
             };
 
             options.ApplyEnvironmentOptions(new EnvironmentOptions(values));
             Assert.Equal("http://collector:4318/my-special-path", options.GetTracesEndpoint());
-        }
-
-        [Fact]
-        public void DoesNotAppendTracesPathToGenericEndpointIfPathSpecified_EnvVars()
-        {
-            var options = new HoneycombOptions { };
-            var values = new Dictionary<string, string>
-            {
-                {"OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf"},
-                {"HONEYCOMB_API_ENDPOINT", "http://collector:4318/my-special-path"}
-            };
-
-            options.ApplyEnvironmentOptions(new EnvironmentOptions(values));
-            Assert.Equal("http://collector:4318/my-special-path", options.GetTracesEndpoint());
+            Assert.DoesNotContain("/v1/traces", options.GetTracesEndpoint());
         }
 
         [Fact]


### PR DESCRIPTION
## Which problem is this PR solving?
This PR follows up on #279 and adds the same logic to append `/v1/metrics` path to the endpoint if the protocol is `http/protobuf` or `http/json`

## Short description of the changes
- Adds smoke tests for metrics
- Consolidates tests with many cases using [`InlineData`](https://learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-with-dotnet-test#add-more-tests)
- Adds logic to append `/v1/metrics` to the generic endpoint if a path is not already specified

