### PR TITLE
Add CircleCI context for nightly package step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,6 +121,7 @@ workflows:
     jobs:
       - test
       - package:
+          context: Honeycomb Secrets for Public Repos
           requires:
             - test
       - smoke_test:


### PR DESCRIPTION
## Which problem is this PR solving?
The nightly build job was updated to also run the package step, however it requires the CircleCI context that contains the GPG certificate details to succeed. This PR adds the CircleCI context to the nighty package step to match the on-demand workflow.

- Fixes #283 

## Short description of the changes
- Adds CircleCI context to nightly step

