### PR TITLE
Update CircleCI config to publish tags correctly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,17 +141,17 @@ workflows:
           filters:
             tags:
               only: /.*/
-            branches:
-              ignore:
-                - /pull\/.*/
-                - /dependabot\/.*/
       - smoke_test:
           requires:
-            - package
+            - test
+          filters:
+            tags:
+              only: /.*/
       - publish_github:
           context: Honeycomb Secrets for Public Repos
           requires:
             - smoke_test
+            - package
           filters:
             tags:
               only: /^v.*/
@@ -161,6 +161,7 @@ workflows:
           context: Honeycomb Secrets for Public Repos
           requires:
             - smoke_test
+            - package
           filters:
             tags:
               only: /^v.*/


### PR DESCRIPTION
## Which problem is this PR solving?
Our CircleCI config was set up in a way that smoke tests and publish steps were not running on tags. This PR updates the logic to make sure publish steps work as expected for tags

## Short description of the changes
- Run smoke tests on everything
- smoke tests & package step can run in parallel
- publish steps depend on smoke tests and package steps

