### PR TITLE
[ci] Fix nightly build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,13 +120,9 @@ workflows:
                 - main
     jobs:
       - test
-      - package:
-          context: Honeycomb Secrets for Public Repos
-          requires:
-            - test
       - smoke_test:
           requires:
-            - package
+            - test
 
   build:
     jobs:


### PR DESCRIPTION
## Which problem is this PR solving?
The nightly build is currently failing because the `package` job requires secrets. This PR removes the `package` job from the nightly build since we don't actually need to create the package to run tests or smoke tests. This change is something that was discussed as we were building the distro but we decided to tackle it later. Since it solves our nightly build problem, we should remove that job from the workflow now.

- Closes #293 

## Short description of the changes
- Removes the package step from the `nightly` workflow

