### PR TITLE
De-bump Npgsql.OpenTelemetry to 6.0.7 to avoid collisions with LTS entityframework

### DIFF
--- a/src/Honeycomb.OpenTelemetry.AutoInstrumentations/Honeycomb.OpenTelemetry.AutoInstrumentations.csproj
+++ b/src/Honeycomb.OpenTelemetry.AutoInstrumentations/Honeycomb.OpenTelemetry.AutoInstrumentations.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Npgsql.OpenTelemetry" Version="7.0.0-rc.1" />
+    <PackageReference Include="Npgsql.OpenTelemetry" Version="6.0.7" />
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.3" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.6" />
     <PackageReference Include="OpenTelemetry.Instrumentation.MySqlData" Version="1.0.0-beta.3" />


### PR DESCRIPTION
Should fix https://github.com/honeycombio/honeycomb-opentelemetry-dotnet/issues/297

We may also want to consider a `ItemGroup Condition=" '$(TargetFramework)' == 'net7.0'` block for this package and its .NET 7 version in the future, but I'd like to avoid that mess as long as possible.

This makes it so that the Npgsql dependency doesn't get all clobbered up when using LTS .NET and EntityFramework with Npgsql.