### PR TITLE
maint: exclude package job on PRs from forks & dependabot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,15 +150,15 @@ workflows:
     jobs:
       - test:
           <<: *filter_always
+      - smoke_test:
+          requires:
+            - test
+          <<: *filter_always
       - package:
           context: Honeycomb Secrets for Public Repos
           requires:
             - test
           <<: *filter_exclude_forks
-      - smoke_test:
-          requires:
-            - test
-          <<: *filter_always
       - publish_github:
           context: Honeycomb Secrets for Public Repos
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,9 @@ workflows:
             - test
           filters:
             tags:
-              only: /.*/
+              only: /^v.*/
+            branches:
+              ignore: /.*/
       - smoke_test:
           requires:
             - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,6 +108,28 @@ jobs:
           name: "Publishing to nuget.org"
           command: dotnet.exe nuget push "build\*.nupkg" -k $env:NUGET_APIKEY -s https://api.nuget.org/v3/index.json
 
+# Apply this filter to jobs that should always run.
+filter_always: &filter_always
+  filters:
+    tags:
+      only: /.*/
+
+# Apply this filter to release-time jobs that should
+# only run when a version tag (v1.2.3) is pushed.
+filter_version_tag: &filter_version_tag
+  filters:
+    tags:
+      only: /^v.*/
+    branches:
+      ignore: /.*/
+
+# Apply this filter to jobs that require secrets, which
+# are unavailable to PRs from forks and Dependabot.
+filter_exclude_forks: &filter_exclude_forks
+  filters:
+    tags:
+      only: /^(?!(pull|dependabot)\/).*$/
+
 workflows:
   version: 2
   nightly:
@@ -127,41 +149,25 @@ workflows:
   build:
     jobs:
       - test:
-          filters:
-            tags:
-              only: /.*/
+          <<: *filter_always
       - package:
           context: Honeycomb Secrets for Public Repos
           requires:
             - test
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/
+          <<: *filter_exclude_forks
       - smoke_test:
           requires:
             - test
-          filters:
-            tags:
-              only: /.*/
+          <<: *filter_always
       - publish_github:
           context: Honeycomb Secrets for Public Repos
           requires:
             - smoke_test
             - package
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/
+          <<: *filter_version_tag
       - publish_nuget:
           context: Honeycomb Secrets for Public Repos
           requires:
             - smoke_test
             - package
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/
+          <<: *filter_version_tag


### PR DESCRIPTION
## Which problem is this PR solving?
The package step is failing on Çircle because it doesn't have authorisation to run for PRs or dependabot PRs. We don't need to runt he package step for PRs.

- Closes #304 

## Short description of the changes
- Update circle config to only run the package workflow step when publishing a tag