### PR TITLE
maint: fix fork filter to ignore branches instead of tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,8 +127,8 @@ filter_version_tag: &filter_version_tag
 # are unavailable to PRs from forks and Dependabot.
 filter_exclude_forks: &filter_exclude_forks
   filters:
-    tags:
-      only: /^(?!(pull|dependabot)\/).*$/
+    branches:
+      ignore: /^(pull|dependabot)\/.*$/
 
 workflows:
   version: 2


### PR DESCRIPTION
## Which problem is this PR solving?

- PRs from forks and dependabot were still running the package job despite the "fix" in #305.

## Short description of the changes

- Change the filter to ignore branches (with a "positive" matching regex instead of a "not" matching regex") instead of tags because it is the branch name that distinguishes forks and dependabot, not tags.

