### PR TITLE
maint: fix ci publish pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,6 +127,8 @@ filter_version_tag: &filter_version_tag
 # are unavailable to PRs from forks and Dependabot.
 filter_exclude_forks: &filter_exclude_forks
   filters:
+    tags:
+      only: /.*/
     branches:
       ignore: /^(pull|dependabot)\/.*$/
 


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- `package` job did not run during publish because it was triggered by a tag rather than a branch commit
- https://app.circleci.com/pipelines/github/honeycombio/honeycomb-opentelemetry-dotnet/1166/workflows/4425b5c8-f7e9-4907-b109-e2efa10d7bfb

## Short description of the changes

- ensure `package` runs on tags
- test tag: https://app.circleci.com/pipelines/github/honeycombio/honeycomb-opentelemetry-dotnet/1168/workflows/0c84745e-ef57-407c-bac3-4e2b7f43c841

