### PR TITLE
IConfiguration for Honeycomb Options

### DIFF
--- a/src/Honeycomb.OpenTelemetry/WebApplicationBuilderExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry/WebApplicationBuilderExtensions.cs
@@ -3,6 +3,22 @@ using Honeycomb.OpenTelemetry;
 namespace Microsoft.Extensions.Configuration
 {
     /// <summary>
+    /// Extension methods for <see cref="ConfigurationManager"/> to help configure Honeycomb with OpenTelemetry.
+    /// </summary>
+    public static class ConfigurationManagerExtensions
+    {
+        /// <summary>
+        /// Attempts to retrieve an instance of <see cref="HoneycombOptions"/> used to configure the OpenTelemetry SDK.
+        /// </summary>
+        public static HoneycombOptions GetHoneycombOptions(this ConfigurationManager builder)
+        {
+            return builder
+                .GetSection(HoneycombOptions.ConfigSectionName)
+                .Get<HoneycombOptions>();
+        }
+    }
+
+    /// <summary>
     /// Extension methods for <see cref="IConfiguration"/> to help configure Honeycomb with OpenTelemetry.
     /// </summary>
     public static class ConfigurationInterfaceExtensions

--- a/src/Honeycomb.OpenTelemetry/WebApplicationBuilderExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry/WebApplicationBuilderExtensions.cs
@@ -3,18 +3,18 @@ using Honeycomb.OpenTelemetry;
 namespace Microsoft.Extensions.Configuration
 {
     /// <summary>
-    /// Extension methods for <see cref="ConfigurationManager"/> to help configure Honeycomb with OpenTelemetry.
+    /// Extension methods for <see cref="IConfiguration"/> to help configure Honeycomb with OpenTelemetry.
     /// </summary>
-    public static class ConfigurationManagerExtensions
+    public static class ConfigurationInterfaceExtensions
     {
         /// <summary>
-        /// Attempts to retrieve an instance of <see cref="HoneycombOptions"/> used to configre the OpenTelemetry SDK.
+        /// Attempts to retrieve an instance of <see cref="HoneycombOptions"/> used to configure the OpenTelemetry SDK.
         /// </summary>
-        public static HoneycombOptions GetHoneycombOptions(this ConfigurationManager builder)
+        public static HoneycombOptions GetHoneycombOptions(this IConfiguration configuration)
         {
-            return builder
+            return configuration
                 .GetSection(HoneycombOptions.ConfigSectionName)
-                .Get<HoneycombOptions>();;
+                .Get<HoneycombOptions>();
         }
     }
 }


### PR DESCRIPTION
## Which problem is this PR solving?

- In cases where the `ConfigurationManager` is not used the `GetHoneycombOptions` method is unavailable (e.g. adding OTel to a sub-module that only receives an `IConfiguration` to work with). 

## Short description of the changes

- Elevate the method dependency to be on `IConfiguration` rather than `ConfigurationManager`

