### PR TITLE
Update aspnetcore instrumentation to 1.0.0-rc9.9

### DIFF
--- a/src/Honeycomb.OpenTelemetry.Instrumentation.AspNetCore/Honeycomb.OpenTelemetry.Instrumentation.AspNetCore.csproj
+++ b/src/Honeycomb.OpenTelemetry.Instrumentation.AspNetCore/Honeycomb.OpenTelemetry.Instrumentation.AspNetCore.csproj
@@ -27,7 +27,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.8" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Honeycomb.OpenTelemetry.Instrumentation.AspNetCore/TracerProviderBuilderExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry.Instrumentation.AspNetCore/TracerProviderBuilderExtensions.cs
@@ -29,14 +29,18 @@ namespace OpenTelemetry.Trace
         /// <param name="options"><see cref="AspNetCoreInstrumentationOptions"/> being configured.</param>
         public static void EnrichWithBaggage(this AspNetCoreInstrumentationOptions options)
         {
-            options.Enrich = (activity, eventName, _) =>
+            options.EnrichWithHttpRequest = (activity, request) =>
             {
-                if (eventName == "OnStartActivity")
+                foreach (var entry in Baggage.Current)
                 {
-                    foreach (var entry in Baggage.Current)
-                    {
-                        activity.SetTag(entry.Key, entry.Value);
-                    }
+                    activity.SetTag(entry.Key, entry.Value);
+                }
+            };
+            options.EnrichWithHttpResponse = (activity, response) =>
+            {
+                foreach (var entry in Baggage.Current)
+                {
+                    activity.SetTag(entry.Key, entry.Value);
                 }
             };
         }


### PR DESCRIPTION
## Which problem is this PR solving?
Bumps AspNetCore instrumentation to latest and updates the enrich usage.

## Short description of the changes
- Updates aspnetcore instrumentation package to 1.0.0-rc9.9
- Replace enrich usage with EnrichWithHttpRequest and EnrichWithHttpResponse
  - see https://github.com/open-telemetry/opentelemetry-dotnet/pull/3749

