### PR TITLE
fix: metrics smoke tests

### DIFF
--- a/smoke-tests/docker-compose.yml
+++ b/smoke-tests/docker-compose.yml
@@ -5,7 +5,6 @@ x-env-base: &env_base
   HONEYCOMB_API_KEY: bogus_key
   HONEYCOMB_DATASET: bogus_dataset
   HONEYCOMB_METRICS_DATASET: bogus_dataset
-  OTEL_METRIC_EXPORT_INTERVAL: 100
   OTEL_SERVICE_NAME: "aspnetcore-example"
   DEBUG: "true"
 

--- a/smoke-tests/smoke-sdk-grpc.bats
+++ b/smoke-tests/smoke-sdk-grpc.bats
@@ -8,7 +8,7 @@ METRICS_DATASET="bogus_dataset"
 
 setup_file() {
 	echo "# 🚧" >&3
-	docker-compose up --detach collector ${CONTAINER_NAME}
+	docker-compose up --build --detach collector ${CONTAINER_NAME}
 	wait_for_ready_app ${CONTAINER_NAME}
 	curl --silent "http://localhost:5001/weatherforecast"
 	wait_for_traces

--- a/smoke-tests/smoke-sdk-http.bats
+++ b/smoke-tests/smoke-sdk-http.bats
@@ -8,7 +8,7 @@ METRICS_DATASET="bogus_dataset"
 
 setup_file() {
 	echo "# 🚧" >&3
-	docker-compose up --detach collector ${CONTAINER_NAME}
+	docker-compose up --build --detach collector ${CONTAINER_NAME}
 	wait_for_ready_app ${CONTAINER_NAME}
 	curl --silent "http://localhost:5001/weatherforecast"
 	wait_for_traces


### PR DESCRIPTION
## Which problem is this PR solving?
When upgrading autoinstrumentation versions to rc9.9, the `OTEL_METRIC_EXPORT_INTERVAL` is supported and our smoke tests export interval is too short (100ms, we're checking for results every 1s) which causes smoke tests to fail. This PR removes the unused env variable.

- Unblocks #319 & #318 

## Short description of the changes
- Removes `OTEL_METRIC_EXPORT_INTERVAL` option set in the smoke tests docker-compose.yml
- Adds `--build` option to smoke tests docker-compose step since without rebuilding it's hard to figure out if you're working with a previously cached build.

