### PR TITLE
Prepare v1.2.0 / v0.26.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # honeycomb-opentelemetry-dotnet changelog
 
+## [1.2.0/0.26.0-beta] - 2022-11-15
+
+
+### Enhancements
+
+- Support IConfiguration with Honeycomb Options (#317) | [@pjwilliams2](https://github.com/pjwilliams2)
+
+### Maintenance
+
+- Remove step from releasing (#312) | [@vreynolds](https://github.com/vreynolds)
+- Update README.md (#313) | [@isaacabraham](https://github.com/isaacabraham)
+- Fix metrics smoke tests (#320) | [@pkanal](https://github.com/pkanal)
+
+### Dependencies
+
+- Bump instrumentation pacakges to 1.0.0-rc9.9 (#318)
+- Update aspnetcore instrumentation to 1.0.0-rc9.9 (#319)
+- Bump OpenTelemetry.Instrumentation.MySqlData from 1.0.0-beta.3 to 1.0.0-beta.4 (#314)
+- Bump OpenTelemetry.Instrumentation.AspNet from 1.0.0-rc9.5 to 1.0.0-rc9.6 (#289)
+- Bump Microsoft.NET.Test.Sdk from 17.3.1 to 17.3.2 (#315)
+- Bump coverlet.collector from 3.1.2 to 3.2.0 (#316)
+
 ## [1.1.0/0.25.0-beta] - 2022-10-27
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # honeycomb-opentelemetry-dotnet changelog
 
-## [1.2.0/0.26.0-beta] - 2022-11-15
+## [1.2.0/0.26.0-beta] - 2022-11-16
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## [1.2.0/0.26.0-beta] - 2022-11-15
 
-
 ### Enhancements
 
 - Support IConfiguration with Honeycomb Options (#317) | [@pjwilliams2](https://github.com/pjwilliams2)

--- a/src/Honeycomb.OpenTelemetry.AutoInstrumentations/Honeycomb.OpenTelemetry.AutoInstrumentations.csproj
+++ b/src/Honeycomb.OpenTelemetry.AutoInstrumentations/Honeycomb.OpenTelemetry.AutoInstrumentations.csproj
@@ -11,7 +11,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
 
     <!-- NuGet packaging properties -->
-    <VersionPrefix>0.25.0</VersionPrefix>
+    <VersionPrefix>0.26.0</VersionPrefix>
     <VersionSuffix>beta</VersionSuffix>
     <PackageId>Honeycomb.OpenTelemetry.AutoInstrumentations</PackageId>
     <Authors>Honeycomb</Authors>

--- a/src/Honeycomb.OpenTelemetry.Instrumentation.AspNetCore/Honeycomb.OpenTelemetry.Instrumentation.AspNetCore.csproj
+++ b/src/Honeycomb.OpenTelemetry.Instrumentation.AspNetCore/Honeycomb.OpenTelemetry.Instrumentation.AspNetCore.csproj
@@ -11,7 +11,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
 
     <!-- NuGet packaging properties -->
-    <VersionPrefix>0.25.0</VersionPrefix>
+    <VersionPrefix>0.26.0</VersionPrefix>
     <VersionSuffix>beta</VersionSuffix>
     <PackageId>Honeycomb.OpenTelemetry.Instrumentation.AspNetCore</PackageId>
     <Authors>Honeycomb</Authors>

--- a/src/Honeycomb.OpenTelemetry/Honeycomb.OpenTelemetry.csproj
+++ b/src/Honeycomb.OpenTelemetry/Honeycomb.OpenTelemetry.csproj
@@ -11,7 +11,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
 
     <!-- NuGet packaging properties -->
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>1.2.0</VersionPrefix>
     <PackageId>Honeycomb.OpenTelemetry</PackageId>
     <Authors>Honeycomb</Authors>
     <Description>Honeycomb's OpenTelemetry SDK</Description>


### PR DESCRIPTION
## Which problem is this PR solving?
Prepares the v1.2.0 release of main distro and v0.26.0 releases of the supporting instrumentation packages.

## Short description of the changes
- Updates distro and instrumentation package versions
- Add changelog entry

