### PR TITLE
fix: Only add Redis instrumentation if connection found in DI

### DIFF
--- a/src/Honeycomb.OpenTelemetry.AutoInstrumentations/TracerProviderBuilderExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry.AutoInstrumentations/TracerProviderBuilderExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Npgsql;
+using StackExchange.Redis;
 
 namespace OpenTelemetry.Trace
 {
@@ -14,6 +15,19 @@ namespace OpenTelemetry.Trace
         /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
         public static TracerProviderBuilder AddAutoInstrumentations(this TracerProviderBuilder builder)
         {
+            // Only add Redis instrumentation if we can find a Redis connection in DI
+            if (builder is IDeferredTracerProviderBuilder deferredBuilder)
+            {
+                deferredBuilder.Configure((sp, b) =>
+                {
+                    var connection = (IConnectionMultiplexer)sp.GetService(typeof(IConnectionMultiplexer));
+                    if (connection != null)
+                    {
+                        b.AddRedisInstrumentation(connection);
+                    }
+                });
+            }
+
             return
                 builder
 #if NET6_0_OR_GREATER
@@ -29,7 +43,6 @@ namespace OpenTelemetry.Trace
                 .AddSqlClientInstrumentation()
                 .AddEntityFrameworkCoreInstrumentation()
                 .AddMySqlDataInstrumentation()
-                .AddRedisInstrumentation()
                 .AddWcfInstrumentation()
                 .AddNpgsql();
         }

--- a/src/Honeycomb.OpenTelemetry.AutoInstrumentations/TracerProviderBuilderExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry.AutoInstrumentations/TracerProviderBuilderExtensions.cs
@@ -20,7 +20,7 @@ namespace OpenTelemetry.Trace
             {
                 deferredBuilder.Configure((sp, b) =>
                 {
-                    var connection = (IConnectionMultiplexer)sp.GetService(typeof(IConnectionMultiplexer));
+                    var connection = sp.GetService(typeof(IConnectionMultiplexer)) as IConnectionMultiplexer;
                     if (connection != null)
                     {
                         b.AddRedisInstrumentation(connection);


### PR DESCRIPTION
## Which problem is this PR solving?
Apps that do not utilise Redis and register a connection before calling `AddAutoInstrumentations` fail to send telemetry. This is because even though the `AddRedisInstrumentation` call has the connection as an optional parameter, an exception is thrown if a connection is not provided and one cannot be found in DI.

This PR updates `AddAutoInstrumentations` to try to find a Redis connection from DI and only call `AddRedisInstrumentation` if one is found.

- Closes #322

## Short description of the changes
- Only add Redis instrumentation if a registered Redis connection is found using DI

