### PR TITLE
Prepare v1.2.1/0.26.1-beta release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # honeycomb-opentelemetry-dotnet changelog
 
+## [1.2.1/0.26.1-beta] - 2022-11-22
+
+### Fixes
+
+- Only add Redis instrumentation if connection found in DI (#323) | [@MikeGoldsmith](https://github.com/MikeGoldsmith)
+
 ## [1.2.0/0.26.0-beta] - 2022-11-16
 
 ### Enhancements

--- a/src/Honeycomb.OpenTelemetry.AutoInstrumentations/Honeycomb.OpenTelemetry.AutoInstrumentations.csproj
+++ b/src/Honeycomb.OpenTelemetry.AutoInstrumentations/Honeycomb.OpenTelemetry.AutoInstrumentations.csproj
@@ -11,7 +11,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
 
     <!-- NuGet packaging properties -->
-    <VersionPrefix>0.26.0</VersionPrefix>
+    <VersionPrefix>0.26.1</VersionPrefix>
     <VersionSuffix>beta</VersionSuffix>
     <PackageId>Honeycomb.OpenTelemetry.AutoInstrumentations</PackageId>
     <Authors>Honeycomb</Authors>

--- a/src/Honeycomb.OpenTelemetry.Instrumentation.AspNetCore/Honeycomb.OpenTelemetry.Instrumentation.AspNetCore.csproj
+++ b/src/Honeycomb.OpenTelemetry.Instrumentation.AspNetCore/Honeycomb.OpenTelemetry.Instrumentation.AspNetCore.csproj
@@ -11,7 +11,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
 
     <!-- NuGet packaging properties -->
-    <VersionPrefix>0.26.0</VersionPrefix>
+    <VersionPrefix>0.26.1</VersionPrefix>
     <VersionSuffix>beta</VersionSuffix>
     <PackageId>Honeycomb.OpenTelemetry.Instrumentation.AspNetCore</PackageId>
     <Authors>Honeycomb</Authors>

--- a/src/Honeycomb.OpenTelemetry/Honeycomb.OpenTelemetry.csproj
+++ b/src/Honeycomb.OpenTelemetry/Honeycomb.OpenTelemetry.csproj
@@ -11,7 +11,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
 
     <!-- NuGet packaging properties -->
-    <VersionPrefix>1.2.0</VersionPrefix>
+    <VersionPrefix>1.2.1</VersionPrefix>
     <PackageId>Honeycomb.OpenTelemetry</PackageId>
     <Authors>Honeycomb</Authors>
     <Description>Honeycomb's OpenTelemetry SDK</Description>


### PR DESCRIPTION
## Which problem is this PR solving?
Prepares the v1.2.1 / 0.26.1-beta release.

## Short description of the changes
- Adds updates version to 1.2.1 for main distro and 0.26.1 for instrumentation packages
- Adds changelog entry

