### PR TITLE
maint: Rename AutoInstrumentations package

### DIFF
--- a/honeycomb-opentelemetry.sln
+++ b/honeycomb-opentelemetry.sln
@@ -21,7 +21,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "aspnetcoreredis", "examples
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Honeycomb.OpenTelemetry.Instrumentation.AspNetCore", "src\Honeycomb.OpenTelemetry.Instrumentation.AspNetCore\Honeycomb.OpenTelemetry.Instrumentation.AspNetCore.csproj", "{DB772676-A314-44DC-8EBD-971FBE6953B9}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honeycomb.OpenTelemetry.AutoInstrumentations", "src\Honeycomb.OpenTelemetry.AutoInstrumentations\Honeycomb.OpenTelemetry.AutoInstrumentations.csproj", "{CA34C8B5-6C46-41C5-8931-AAFAD732DF5F}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Honeycomb.OpenTelemetry.CommonInstrumentations", "src\Honeycomb.OpenTelemetry.CommonInstrumentations\Honeycomb.OpenTelemetry.CommonInstrumentations.csproj", "{CA34C8B5-6C46-41C5-8931-AAFAD732DF5F}"
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "aspnetcore-fsharp", "examples\aspnetcore-fsharp\aspnetcore-fsharp.fsproj", "{72DF2078-62A4-4529-B439-BFFF4AD4C6B9}"
 EndProject

--- a/src/Honeycomb.OpenTelemetry.CommonInstrumentations/Honeycomb.OpenTelemetry.CommonInstrumentations.csproj
+++ b/src/Honeycomb.OpenTelemetry.CommonInstrumentations/Honeycomb.OpenTelemetry.CommonInstrumentations.csproj
@@ -13,9 +13,9 @@
     <!-- NuGet packaging properties -->
     <VersionPrefix>0.26.1</VersionPrefix>
     <VersionSuffix>beta</VersionSuffix>
-    <PackageId>Honeycomb.OpenTelemetry.AutoInstrumentations</PackageId>
+    <PackageId>Honeycomb.OpenTelemetry.CommonInstrumentations</PackageId>
     <Authors>Honeycomb</Authors>
-    <Description>Honeycomb's OpenTelemetry autoinstrumentations package. Adds support for many common instrumentation libraries for you.</Description>
+    <Description>Honeycomb's OpenTelemetry common instrumentations package. Adds support for many common instrumentation libraries for you.</Description>
     <PackageProjectUrl>https://docs.honeycomb.io/getting-data-in/dotnet/</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageReleaseNotes>https://github.com/honeycombio/honeycomb-opentelemetry-dotnet/blob/main/CHANGELOG.md</PackageReleaseNotes>

--- a/src/Honeycomb.OpenTelemetry.CommonInstrumentations/TracerProviderBuilderExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry.CommonInstrumentations/TracerProviderBuilderExtensions.cs
@@ -13,7 +13,7 @@ namespace OpenTelemetry.Trace
         /// </summary>
         /// <param name="builder"><see cref="TracerProviderBuilder"/> being configured.</param>
         /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
-        public static TracerProviderBuilder AddAutoInstrumentations(this TracerProviderBuilder builder)
+        public static TracerProviderBuilder AddCommonInstrumentations(this TracerProviderBuilder builder)
         {
             // Only add Redis instrumentation if we can find a Redis connection in DI
             if (builder is IDeferredTracerProviderBuilder deferredBuilder)


### PR DESCRIPTION
## Which problem is this PR solving?
The AutoInstrumentations package doesn't accurately describe what the package actually does. It wires up some common instrumentation packages automatically for you, it does not have anything to do with auto instrumentation.

This PR renames the package to be more clear on what it does.

## Short description of the changes
- Rename Honeycomb.OpenTelemetry.AutoInstrumentations directory to Honeycomb.OpenTelemetry.CommonInstrumentations
- Rename csproj and update internals to use CommonInstrumentations
- Update AddAutoInstrumentations with AddCommonInstrumentations