### PR TITLE
rel: prepare v1.3.0/v0.27.0-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # honeycomb-opentelemetry-dotnet changelog
 
+## [1.2.1/0.27.0-beta] - 2023-02-28
+
+### !!! Breaking Changes !!!
+
+### Maintenance
+
+- maint: Rename AutoInstrumentations package to CommonInstrumentations (#327) | [@MikeGoldsmith](https://github.com/MikeGoldsmith)
+  - renamed the package to make it more clear that this is common instrumentation, not technically "automatic" instrumentation.
+  - `Honeycomb.OpenTelemetry.AutoInstrumentations` -> `Honeycomb.OpenTelemetry.CommonInstrumentations`
+  - `AddAutoInstrumentations` -> `AddCommonInstrumentations`
+
 ## [1.2.1/0.26.1-beta] - 2022-11-22
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # honeycomb-opentelemetry-dotnet changelog
 
-## [1.2.1/0.27.0-beta] - 2023-02-28
+## [1.3.0/0.27.0-beta] - 2023-03-02
 
 ### !!! Breaking Changes !!!
 
@@ -10,6 +10,13 @@
   - renamed the package to make it more clear that this is common instrumentation, not technically "automatic" instrumentation.
   - `Honeycomb.OpenTelemetry.AutoInstrumentations` -> `Honeycomb.OpenTelemetry.CommonInstrumentations`
   - `AddAutoInstrumentations` -> `AddCommonInstrumentations`
+- maint: Update OpenTelemetry instrumentation packages (#334) | [@MikeGoldsmith](https://github.com/MikeGoldsmith)
+  - The new `OpenTelemetry` packages change how tracing and metrics are setup
+  - `AddOpenTelemetryTracing` -> `AddOpenTelemetry().WithTracing`
+  - `AddOpenTelemetryMetrics` -> `AddOpenTelemetry().WithMetrics`
+- maint(deps): bump OpenTelemetry.Instrumentation.StackExchangeRedis from 1.0.0-rc9.7 to 1.0.0-rc9.8 (#345)
+- maint(deps): bump Microsoft.NET.Test.Sdk from 17.3.2 to 17.4.1 (#336)
+- maint: new signed snkgpg, use long cmd lines for clarity (#341) | [@JamieDanielson](https://github.com/JamieDanielson)
 
 ## [1.2.1/0.26.1-beta] - 2022-11-22
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It makes getting started with OpenTelemetry and Honeycomb easier!
 
 Latest release built with:
 
-- [OpenTelemetry Version 1.3.0](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.3.0)
+- [OpenTelemetry Version 1.4.0](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.4.0)
 
 ## Getting Started
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,9 +1,14 @@
 # Releasing Process
 
-1. Update changelog
-2. Update VersionPrefix (and VersionSuffix if necessary) in the csproj file
-    - If updating the OTel SDK, update the OTLP version in `HoneycombOptions.cs`
-3. Open a PR with the above, and merge that into main
-4. Tag the merged commit with the new version (e.g. `v0.10.0-alpha`)
-5. Push the tag upstream (this will kick off the release pipeline in CI)
-6. Once the CI is done, publish the GitHub draft release as pre-release through GitHub UI
+- Update `CHANGELOG.md` with the changes since the last release. Consider automating with a command such as these two:
+  - `git log $(git describe --tags --abbrev=0)..HEAD --no-merges --oneline > new-in-this-release.log`
+  - `git log --pretty='%C(green)%d%Creset- %s | [%an](https://github.com/)'`
+- Update VersionPrefix (and VersionSuffix if necessary) in the `*.csproj` files
+  - If updating the OTel SDK, update the OTLP version in `HoneycombOptions.cs`
+- Commit changes, push, and open a release preparation pull request for review.
+- Once the pull request is merged, fetch the updated `main` branch.
+- Apply a tag for the new version on the merged commit (e.g. `git tag -a v1.2.1v/0.26.1-beta -m "v1.2.1v/0.26.1-beta"`)
+- Push the tag upstream (this will kick off the release pipeline in CI) e.g. `git push origin v1.2.1v/0.26.1-beta`
+- Ensure that there is a draft GitHub release created as part of CI publish steps (this will also publish to Nuget).
+- Click "generate release notes" in Github for full changelog notes and any new contributors
+- Publish the Github draft release - if it is a prerelease (e.g. beta) click the prerelease checkbox.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,6 +5,7 @@
   - `git log --pretty='%C(green)%d%Creset- %s | [%an](https://github.com/)'`
 - Update VersionPrefix (and VersionSuffix if necessary) in the `*.csproj` files
   - If updating the OTel SDK, update the OTLP version in `HoneycombOptions.cs`
+  - If updating the OTel SDK, update the OTel version in `README.md`
 - Commit changes, push, and open a release preparation pull request for review.
 - Once the pull request is merged, fetch the updated `main` branch.
 - Apply a tag for the new version on the merged commit (e.g. `git tag -a v1.3.0 -m "v1.3.0"`)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,8 +7,9 @@
   - If updating the OTel SDK, update the OTLP version in `HoneycombOptions.cs`
 - Commit changes, push, and open a release preparation pull request for review.
 - Once the pull request is merged, fetch the updated `main` branch.
-- Apply a tag for the new version on the merged commit (e.g. `git tag -a v1.2.1v/0.26.1-beta -m "v1.2.1v/0.26.1-beta"`)
-- Push the tag upstream (this will kick off the release pipeline in CI) e.g. `git push origin v1.2.1v/0.26.1-beta`
+- Apply a tag for the new version on the merged commit (e.g. `git tag -a v1.3.0 -m "v1.3.0"`)
+  - Note: We only tag the main package (even if changes were made to the instr packages) so the pipeline doesn't double-run
+- Push the tag upstream (this will kick off the release pipeline in CI) e.g. `git push origin v1.3.0`
 - Ensure that there is a draft GitHub release created as part of CI publish steps (this will also publish to Nuget).
 - Click "generate release notes" in Github for full changelog notes and any new contributors
 - Publish the Github draft release - if it is a prerelease (e.g. beta) click the prerelease checkbox.

--- a/src/Honeycomb.OpenTelemetry.CommonInstrumentations/Honeycomb.OpenTelemetry.CommonInstrumentations.csproj
+++ b/src/Honeycomb.OpenTelemetry.CommonInstrumentations/Honeycomb.OpenTelemetry.CommonInstrumentations.csproj
@@ -11,7 +11,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
 
     <!-- NuGet packaging properties -->
-    <VersionPrefix>0.26.1</VersionPrefix>
+    <VersionPrefix>0.27.0</VersionPrefix>
     <VersionSuffix>beta</VersionSuffix>
     <PackageId>Honeycomb.OpenTelemetry.CommonInstrumentations</PackageId>
     <Authors>Honeycomb</Authors>

--- a/src/Honeycomb.OpenTelemetry.Instrumentation.AspNetCore/Honeycomb.OpenTelemetry.Instrumentation.AspNetCore.csproj
+++ b/src/Honeycomb.OpenTelemetry.Instrumentation.AspNetCore/Honeycomb.OpenTelemetry.Instrumentation.AspNetCore.csproj
@@ -11,7 +11,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
 
     <!-- NuGet packaging properties -->
-    <VersionPrefix>0.26.1</VersionPrefix>
+    <VersionPrefix>0.27.0</VersionPrefix>
     <VersionSuffix>beta</VersionSuffix>
     <PackageId>Honeycomb.OpenTelemetry.Instrumentation.AspNetCore</PackageId>
     <Authors>Honeycomb</Authors>

--- a/src/Honeycomb.OpenTelemetry/Honeycomb.OpenTelemetry.csproj
+++ b/src/Honeycomb.OpenTelemetry/Honeycomb.OpenTelemetry.csproj
@@ -11,7 +11,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
 
     <!-- NuGet packaging properties -->
-    <VersionPrefix>1.2.1</VersionPrefix>
+    <VersionPrefix>1.3.0</VersionPrefix>
     <PackageId>Honeycomb.OpenTelemetry</PackageId>
     <Authors>Honeycomb</Authors>
     <Description>Honeycomb's OpenTelemetry SDK</Description>

--- a/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
+++ b/src/Honeycomb.OpenTelemetry/HoneycombOptions.cs
@@ -12,7 +12,7 @@ namespace Honeycomb.OpenTelemetry
     /// </summary>
     public class HoneycombOptions
     {
-        private const string OtlpVersion = "0.18.0";
+        private const string OtlpVersion = "0.19.0";
         private const string OtelExporterOtlpProtocolHttpProtobuf = "http/protobuf";
         private const string OtelExporterOtlpProtocolHttpJson = "http/json";
         private const string OtelExporterOtlpProtocolGrpc = "grpc";

--- a/test/Honeycomb.OpenTelemetry.Tests/HoneycombOptionsExtensionsTests.cs
+++ b/test/Honeycomb.OpenTelemetry.Tests/HoneycombOptionsExtensionsTests.cs
@@ -7,11 +7,11 @@ namespace Honeycomb.OpenTelemetry {
         private const string ClassicApiKey = "a142c03cf06936628e60f4c6157fde46";
 
         [Theory]
-        [InlineData("", "", "x-otlp-version=0.18.0,x-honeycomb-team=")]
-        [InlineData(ModernApiKey, "", "x-otlp-version=0.18.0,x-honeycomb-team=6936628e60f4c6157fde46")]
-        [InlineData(ModernApiKey, "dataset", "x-otlp-version=0.18.0,x-honeycomb-team=6936628e60f4c6157fde46")]
-        [InlineData(ClassicApiKey, "", "x-otlp-version=0.18.0,x-honeycomb-team=a142c03cf06936628e60f4c6157fde46")]
-        [InlineData(ClassicApiKey, "dataset", "x-otlp-version=0.18.0,x-honeycomb-team=a142c03cf06936628e60f4c6157fde46,x-honeycomb-dataset=dataset")]
+        [InlineData("", "", "x-otlp-version=0.19.0,x-honeycomb-team=")]
+        [InlineData(ModernApiKey, "", "x-otlp-version=0.19.0,x-honeycomb-team=6936628e60f4c6157fde46")]
+        [InlineData(ModernApiKey, "dataset", "x-otlp-version=0.19.0,x-honeycomb-team=6936628e60f4c6157fde46")]
+        [InlineData(ClassicApiKey, "", "x-otlp-version=0.19.0,x-honeycomb-team=a142c03cf06936628e60f4c6157fde46")]
+        [InlineData(ClassicApiKey, "dataset", "x-otlp-version=0.19.0,x-honeycomb-team=a142c03cf06936628e60f4c6157fde46,x-honeycomb-dataset=dataset")]
         public void TracesHeaders(string apikey, string dataset, string expectedHeader) {
             var options = new HoneycombOptions
             {
@@ -22,11 +22,11 @@ namespace Honeycomb.OpenTelemetry {
         }
 
         [Theory]
-        [InlineData("", "", "x-otlp-version=0.18.0,x-honeycomb-team=,x-honeycomb-dataset=")]
-        [InlineData(ModernApiKey, "", "x-otlp-version=0.18.0,x-honeycomb-team=6936628e60f4c6157fde46,x-honeycomb-dataset=")]
-        [InlineData(ModernApiKey, "dataset", "x-otlp-version=0.18.0,x-honeycomb-team=6936628e60f4c6157fde46,x-honeycomb-dataset=dataset")]
-        [InlineData(ClassicApiKey, "", "x-otlp-version=0.18.0,x-honeycomb-team=a142c03cf06936628e60f4c6157fde46,x-honeycomb-dataset=")]
-        [InlineData(ClassicApiKey, "dataset", "x-otlp-version=0.18.0,x-honeycomb-team=a142c03cf06936628e60f4c6157fde46,x-honeycomb-dataset=dataset")]
+        [InlineData("", "", "x-otlp-version=0.19.0,x-honeycomb-team=,x-honeycomb-dataset=")]
+        [InlineData(ModernApiKey, "", "x-otlp-version=0.19.0,x-honeycomb-team=6936628e60f4c6157fde46,x-honeycomb-dataset=")]
+        [InlineData(ModernApiKey, "dataset", "x-otlp-version=0.19.0,x-honeycomb-team=6936628e60f4c6157fde46,x-honeycomb-dataset=dataset")]
+        [InlineData(ClassicApiKey, "", "x-otlp-version=0.19.0,x-honeycomb-team=a142c03cf06936628e60f4c6157fde46,x-honeycomb-dataset=")]
+        [InlineData(ClassicApiKey, "dataset", "x-otlp-version=0.19.0,x-honeycomb-team=a142c03cf06936628e60f4c6157fde46,x-honeycomb-dataset=dataset")]
         public void MetricsHeaders(string apikey, string dataset, string expectedHeader) {
             var options = new HoneycombOptions
             {


### PR DESCRIPTION
## Which problem is this PR solving?

- release of new main package, including dependency updates and method changes from OTel v1.4.0
- release of new instrumentation package, including name change

## Short description of the changes

- add changelog entries.
  - We renamed `AutoInstrumentations` to `CommonInstrumentations`; see #327 for more details.
  - OTel changed to `AddOpenTelemetry().WithTracing` and `AddOpenTelemetry().WithMetrics`; see #334 for more details.
  - Update versions of main package from 1.2.1 to 1.3.0
- Update versions of instrumentation packages from 0.26.1-beta to 0.27.0-beta
- Update releasing notes with extra details for clarity


Once the release is out, docs updates can be merged in for public docs and in-app onboarding (see #339 )
