### PR TITLE
fix: De-bump Npgsql.OpenTelemetry to work with LTS EntityFramework

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,4 +19,4 @@ updates:
     ignore:
       # We don't target .NET 7 yet and this breaks LTS EFCore
       - dependency-name: "Npgsql.OpenTelemetry"
-        versions: ["version-update:semver-major"]
+        update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,7 @@ updates:
     commit-message:
       prefix: "maint"
       include: "scope"
+    ignore:
+      # We don't target .NET 7 yet and this breaks LTS EFCore
+      - dependency-name: "Npgsql.OpenTelemetry"
+        versions: ["version-update:semver-major"]

--- a/src/Honeycomb.OpenTelemetry.CommonInstrumentations/Honeycomb.OpenTelemetry.CommonInstrumentations.csproj
+++ b/src/Honeycomb.OpenTelemetry.CommonInstrumentations/Honeycomb.OpenTelemetry.CommonInstrumentations.csproj
@@ -42,7 +42,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Npgsql.OpenTelemetry" Version="7.0.2" />
+    <PackageReference Include="Npgsql.OpenTelemetry" Version="6.0.7" />
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.5" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.14" />
     <PackageReference Include="OpenTelemetry.Instrumentation.MySqlData" Version="1.0.0-beta.6" />

--- a/src/Honeycomb.OpenTelemetry.CommonInstrumentations/Honeycomb.OpenTelemetry.CommonInstrumentations.csproj
+++ b/src/Honeycomb.OpenTelemetry.CommonInstrumentations/Honeycomb.OpenTelemetry.CommonInstrumentations.csproj
@@ -42,7 +42,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Npgsql.OpenTelemetry" Version="6.0.7" />
+    <PackageReference Include="Npgsql.OpenTelemetry" Version="6.0.9" />
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.5" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.14" />
     <PackageReference Include="OpenTelemetry.Instrumentation.MySqlData" Version="1.0.0-beta.6" />


### PR DESCRIPTION
## Which problem is this PR solving?

- error when using with EFCore `Encountered Exception of type MethodAccessException: Attempt by method 'Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.NpgsqlRelationalConnection.get_CurrentAmbientTransaction()' to access method 'Npgsql.NpgsqlConnection.get_Settings()' failed`

## Short description of the changes

- Similar to #298 there seem to be some issues with EntityFramework with .NET 7. This reverts back to 6.0.7, but adds a bump to a later patch version of 6.0.9.
- If this indeed solves the problem, a follow-up issue should be added for separating out versions for .NET 6 and .NET 7. We don't currently include net7.0 in this package so it doesn't make sense to add that conditional block here.
- In the meantime, I added a dependabot ignore block so we don't inadvertently update again; we can remove it once we update with conditionals for .NET 7.
