### PR TITLE
maint: Bump OpenTelemetry dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ This can lead to the same option being set multiple times with the last one wins
 
 For example, the `AddHoneycomb(options)` function configures a Sampler so another call to `SetSampler(sampler)` will override the first sampler.
 
+
+### HTTP Semantic Conventions
+
+The semantic conventions for attribute names used in HTTP instrumentation libraries is being updated and could cause distruption for existing users who rely on the existing names.
+For this reason, we have locked HTTP instrumentation packages to [1.6.0-beta.1](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/1.6.0-beta.3) which includes the `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable that allows users to opt-in to the new behaviour when they are ready to.
+
+See this [Migration Guide](https://docs.honeycomb.io/getting-data-in/semconv/migration) for details on how to switch between the old and new attribute keys when using Honeycomb.
+
 ## License
 
 [Apache 2.0 License](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ For example, the `AddHoneycomb(options)` function configures a Sampler so anothe
 ### HTTP Semantic Conventions
 
 The semantic conventions for attribute names used in HTTP instrumentation libraries is being updated and could cause distruption for existing users who rely on the existing names.
-For this reason, we have locked HTTP instrumentation packages to [1.6.0-beta.1](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/1.6.0-beta.3) which includes the `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable that allows users to opt-in to the new behaviour when they are ready to.
+For this reason, we have locked HTTP instrumentation packages to [1.6.0-beta.3](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/1.6.0-beta.3) which includes the `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable that allows users to opt-in to the new behaviour when they are ready to.
 
 See this [Migration Guide](https://docs.honeycomb.io/getting-data-in/semconv/migration) for details on how to switch between the old and new attribute keys when using Honeycomb.
 

--- a/src/Honeycomb.OpenTelemetry.CommonInstrumentations/Honeycomb.OpenTelemetry.CommonInstrumentations.csproj
+++ b/src/Honeycomb.OpenTelemetry.CommonInstrumentations/Honeycomb.OpenTelemetry.CommonInstrumentations.csproj
@@ -44,9 +44,9 @@
   <ItemGroup>
     <PackageReference Include="Npgsql.OpenTelemetry" Version="6.0.9" />
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.10" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.7.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.6.0-beta.3" />
     <PackageReference Include="OpenTelemetry.Instrumentation.MySqlData" Version="1.0.0-beta.7" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.7.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.6.0-beta.3" />
     <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.0.0-rc9.13" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Wcf" Version="1.0.0-rc.15" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Quartz" Version="1.0.0-beta.1" />

--- a/src/Honeycomb.OpenTelemetry.CommonInstrumentations/Honeycomb.OpenTelemetry.CommonInstrumentations.csproj
+++ b/src/Honeycomb.OpenTelemetry.CommonInstrumentations/Honeycomb.OpenTelemetry.CommonInstrumentations.csproj
@@ -33,23 +33,23 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <PackageReference Include="OpenTelemetry.Instrumentation.Owin" Version="1.0.0-rc.3" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNet" Version="1.0.0-rc9.8" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNet" Version="1.7.0-beta.2" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And
                         $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '6.0'))">
-    <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.0.0-rc9.14" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.7.0-beta.1" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Npgsql.OpenTelemetry" Version="6.0.9" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.6" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.14" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.MySqlData" Version="1.0.0-beta.6" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.0.0-rc9.14" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.0.0-rc9.8" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Wcf" Version="1.0.0-rc.9" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Quartz" Version="1.0.0-alpha.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.10" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.7.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.MySqlData" Version="1.0.0-beta.7" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.7.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.0.0-rc9.13" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Wcf" Version="1.0.0-rc.15" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Quartz" Version="1.0.0-beta.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Honeycomb.OpenTelemetry.CommonInstrumentations/Honeycomb.OpenTelemetry.CommonInstrumentations.csproj
+++ b/src/Honeycomb.OpenTelemetry.CommonInstrumentations/Honeycomb.OpenTelemetry.CommonInstrumentations.csproj
@@ -33,7 +33,7 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <PackageReference Include="OpenTelemetry.Instrumentation.Owin" Version="1.0.0-rc.3" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNet" Version="1.7.0-beta.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNet" Version="1.6.0-beta.2" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And
@@ -43,13 +43,13 @@
 
   <ItemGroup>
     <PackageReference Include="Npgsql.OpenTelemetry" Version="6.0.9" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.10" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.8" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.6.0-beta.3" />
     <PackageReference Include="OpenTelemetry.Instrumentation.MySqlData" Version="1.0.0-beta.7" />
     <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.6.0-beta.3" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.0.0-rc9.13" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Wcf" Version="1.0.0-rc.15" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Quartz" Version="1.0.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.0.0-rc9.12" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Wcf" Version="1.0.0-rc.13" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Quartz" Version="1.0.0-alpha.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Honeycomb.OpenTelemetry.CommonInstrumentations/Honeycomb.OpenTelemetry.CommonInstrumentations.csproj
+++ b/src/Honeycomb.OpenTelemetry.CommonInstrumentations/Honeycomb.OpenTelemetry.CommonInstrumentations.csproj
@@ -38,7 +38,7 @@
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And
                         $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '6.0'))">
-    <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.7.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.6.0-beta.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Honeycomb.OpenTelemetry.Instrumentation.AspNetCore/Honeycomb.OpenTelemetry.Instrumentation.AspNetCore.csproj
+++ b/src/Honeycomb.OpenTelemetry.Instrumentation.AspNetCore/Honeycomb.OpenTelemetry.Instrumentation.AspNetCore.csproj
@@ -27,7 +27,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.14" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.7.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Honeycomb.OpenTelemetry.Instrumentation.AspNetCore/Honeycomb.OpenTelemetry.Instrumentation.AspNetCore.csproj
+++ b/src/Honeycomb.OpenTelemetry.Instrumentation.AspNetCore/Honeycomb.OpenTelemetry.Instrumentation.AspNetCore.csproj
@@ -27,7 +27,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.7.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.6.0-beta.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Honeycomb.OpenTelemetry.Instrumentation.AspNetCore/TracerProviderBuilderExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry.Instrumentation.AspNetCore/TracerProviderBuilderExtensions.cs
@@ -26,8 +26,8 @@ namespace OpenTelemetry.Trace
         /// <summary>
         /// Configures the AspNetCore instrumentation to adds current trace context baggage as attributes to created spans.
         /// </summary>
-        /// <param name="options"><see cref="AspNetCoreTraceInstrumentationOptions"/> being configured.</param>
-        public static void EnrichWithBaggage(this AspNetCoreTraceInstrumentationOptions options)
+        /// <param name="options"><see cref="AspNetCoreInstrumentationOptions"/> being configured.</param>
+        public static void EnrichWithBaggage(this AspNetCoreInstrumentationOptions options)
         {
             options.EnrichWithHttpRequest = (activity, request) =>
             {

--- a/src/Honeycomb.OpenTelemetry.Instrumentation.AspNetCore/TracerProviderBuilderExtensions.cs
+++ b/src/Honeycomb.OpenTelemetry.Instrumentation.AspNetCore/TracerProviderBuilderExtensions.cs
@@ -26,8 +26,8 @@ namespace OpenTelemetry.Trace
         /// <summary>
         /// Configures the AspNetCore instrumentation to adds current trace context baggage as attributes to created spans.
         /// </summary>
-        /// <param name="options"><see cref="AspNetCoreInstrumentationOptions"/> being configured.</param>
-        public static void EnrichWithBaggage(this AspNetCoreInstrumentationOptions options)
+        /// <param name="options"><see cref="AspNetCoreTraceInstrumentationOptions"/> being configured.</param>
+        public static void EnrichWithBaggage(this AspNetCoreTraceInstrumentationOptions options)
         {
             options.EnrichWithHttpRequest = (activity, request) =>
             {

--- a/src/Honeycomb.OpenTelemetry/Honeycomb.OpenTelemetry.csproj
+++ b/src/Honeycomb.OpenTelemetry/Honeycomb.OpenTelemetry.csproj
@@ -33,6 +33,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageReference Include="System.Text.Json" Version="7.0.2" />
   </ItemGroup>
 

--- a/src/Honeycomb.OpenTelemetry/Honeycomb.OpenTelemetry.csproj
+++ b/src/Honeycomb.OpenTelemetry/Honeycomb.OpenTelemetry.csproj
@@ -32,6 +32,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
+    <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
     <PackageReference Include="System.Text.Json" Version="7.0.2" />
   </ItemGroup>
 

--- a/src/Honeycomb.OpenTelemetry/Honeycomb.OpenTelemetry.csproj
+++ b/src/Honeycomb.OpenTelemetry/Honeycomb.OpenTelemetry.csproj
@@ -26,9 +26,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="1.4.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.4.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.4.0" />
+    <PackageReference Include="OpenTelemetry" Version="1.7.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.7.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.7.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />

--- a/src/Honeycomb.OpenTelemetry/Honeycomb.OpenTelemetry.csproj
+++ b/src/Honeycomb.OpenTelemetry/Honeycomb.OpenTelemetry.csproj
@@ -26,9 +26,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry" Version="1.7.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.7.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.7.0" />
+    <PackageReference Include="OpenTelemetry" Version="1.6.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.6.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.6.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />


### PR DESCRIPTION
## Which problem is this PR solving?
Bumps all OpenTelemetry dependencies across packages. However, due to HTTP semantic convention changes coming in minor releases, we have not upgraded to the latest packages available. Instead, we've upgrade the instrumentation packages to the latest version ([1.6.0-beta.3](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/1.6.0-beta.3)) that defaults to the old attribute names and offers an environment to use the names or dual write old & new. The remaining packages were updated to the latest version available when the affected instr package were released (November 17 2023).

- Closes #364 

## Short description of the changes
- Bumps OTel instrumentation packacges to 1.6.0-beta.3
- Bumps remaining OTel dependnencies to latest version available when those instr packages were published
- Add note to README to indicate why we've locked to a particular version and link to our HTTP semantic convention docs guide